### PR TITLE
proxy get_*name() methods in DynamicListSerializer

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -13,6 +13,12 @@ class DynamicListSerializer(serializers.ListSerializer):
         iterable = data.all() if isinstance(data, models.Manager) else data
         return [self.child.to_representation(item) for item in iterable]
 
+    def get_name(self):
+        return self.child.get_name()
+
+    def get_plural_name(self):
+        return self.child.get_plural_name()
+
     @property
     def data(self):
         if not hasattr(self, '_sideloaded_data'):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from django.test import TestCase
-from dynamic_rest.serializers import EphemeralObject
+from dynamic_rest.serializers import EphemeralObject, DynamicListSerializer
 from tests.serializers import (
     UserSerializer, GroupSerializer, LocationGroupSerializer
 )
@@ -370,6 +370,15 @@ class TestUserSerializer(TestCase):
         expected = ['id', 'name']
         self.assertEqual(f2.keys(), expected)
         self.assertEqual(all_keys1, all_keys2)
+
+
+class TestSerializerMethods(TestCase):
+    def testSerializerNameProxying(self):
+        us = UserSerializer(include_fields='*')
+        perm_srzr = us.fields['permissions'].serializer
+        self.assertTrue(isinstance(perm_srzr, DynamicListSerializer))
+        self.assertEqual(perm_srzr.get_name(), 'permission')
+        self.assertEqual(perm_srzr.get_plural_name(), 'permissions')
 
 
 class TestEphemeralSerializer(TestCase):


### PR DESCRIPTION
To be able to do:

```
parent_serializer.fields['children'].serializer.get_plural_name()
                                       ^-- can be a list serializer
```
