### PR TITLE
Fix/always request id fields

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -213,7 +213,8 @@ class DynamicFilterBackend(BaseFilterBackend):
             use_only = True
 
         if use_only:
-            only = set(serializer.get_id_fields() + list(only))
+            id_fields = getattr(serializer, 'get_id_fields', lambda: [])()
+            only = set(id_fields + list(only))
             queryset = queryset.only(*only)
 
         q = self._filters_to_query(


### PR DESCRIPTION
Over in Apollo, ALOs (mptt objects) seem to always need `parent_id`, and a separate query will be issued to fetch it if not prefetched. This change will address that (we already do it for `id_only()` cases, but doing it in all cases should be pretty harmless).
