### PR TITLE
use get_all_related_objects to properly identify related_name/accessor_name mismatches

### DIFF
--- a/dynamic_rest/fields.py
+++ b/dynamic_rest/fields.py
@@ -21,15 +21,14 @@ def field_is_remote(model, field_name):
         model_field = meta.get_field_by_name(field_name)[0]
         return isinstance(model_field, (ManyToManyField, RelatedObject))
     except:
-        related_objects = chain(
-            meta.get_all_related_objects(),
-            meta.get_all_related_many_to_many_objects()
-        )
-        related_objects_map = {
-            o.get_accessor_name(): o
-            for o in related_objects
+        related_object_names = {
+            o.get_accessor_name()
+            for o in chain(
+                meta.get_all_related_objects(),
+                meta.get_all_related_many_to_many_objects()
+            )
         }
-        if field_name in related_objects_map:
+        if field_name in related_object_names:
             return True
         else:
             raise AttributeError(


### PR DESCRIPTION
@ryochiji this removes the `_set` check we were doing and instead uses the meta-methods that return related objects to check whether a field represents a remote/relatedobject.

Ran into an issue with this logic for a particularly weird case in our models:

`financial = ForeignKey('Financials', related_name='discounts', related_query_name='discount')`

The current check did not determine that `discounts` was a remote field because (crazy Django behavior here) the `_meta.get_field_by_name` method does not understand that `discounts` is actually a field. It considers the field to be named `discount` in this case. Pretty bizarre, but looking around it seems that this is a more reliable way to check for remotes.
