### PR TITLE
fix serializer hierarchy linking (specifically for context trickling)

### DIFF
--- a/dynamic_rest/fields.py
+++ b/dynamic_rest/fields.py
@@ -131,6 +131,7 @@ class DynamicRelationField(DynamicField):
             **
             {k: v for k, v in self.kwargs.iteritems()
              if k in self.SERIALIZER_KWARGS})
+        serializer.parent = self
         self._serializer = serializer
         return serializer
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -501,3 +501,8 @@ class TestEphemeralSerializer(TestCase):
         data = NestedEphemeralSerializer(
             request_fields={'value_count': {}}).to_representation(nested)
         self.assertEqual(data['value_count']['count'], 0)
+
+    def testNestedContext(self):
+        s1 = LocationGroupSerializer(context={'foo': 'bar'})
+        s2 = s1.fields['location'].serializer
+        self.assertEqual(s2.context['foo'], 'bar')


### PR DESCRIPTION
@aleontiev - Ran into an issue where context wasn't trickling down properly for nested serializers, and traced it to the fact that the serializer hierarchy is broken because `parent` isn't set when `DynamicRelationField` creates child serializers. Serializers don't accept `parent` as an init arg, and I don't know if it makes sense to call `bind()` on them either... so this seemed like the next most reasonable solution.
