### PR TITLE
fix filter rewrites for m2o/m2m fields

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -1,6 +1,9 @@
 from django.db.models import Q, Prefetch
+from django.db.models.related import RelatedObject
 from dynamic_rest.datastructures import TreeMap
-from dynamic_rest.fields import DynamicRelationField, field_is_remote
+from dynamic_rest.fields import (
+    DynamicRelationField, field_is_remote, get_model_field
+)
 
 from rest_framework.exceptions import ValidationError
 from rest_framework import serializers
@@ -56,9 +59,9 @@ class FilterNode(object):
             # For remote fields, strip off '_set' for filtering. This is a
             # weird Django inconsistency.
             model_field_name = field.source or field_name
-            if model_field_name.endswith('_set') and field_is_remote(
-                    s.get_model(), model_field_name):
-                model_field_name = model_field_name[:-4]
+            model_field = get_model_field(s.get_model(), model_field_name)
+            if isinstance(model_field, RelatedObject):
+                model_field_name = model_field.field.related_query_name()
 
             # If get_all_fields() was used above, field could be unbound,
             # and field.source would be None

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,6 +11,17 @@ class User(models.Model):
     location = models.ForeignKey('Location', null=True, blank=True)
 
 
+class Cat(models.Model):
+    name = models.TextField()
+    home = models.ForeignKey('Location')
+    backup_home = models.ForeignKey('Location', related_name='friendly_cats')
+    hunting_grounds = models.ManyToManyField(
+        'Location',
+        related_name='annoying_cats',
+        related_query_name='getoffmylawn'
+    )
+
+
 class Group(models.Model):
     name = models.TextField()
     permissions = models.ManyToManyField('Permission', related_name='groups')

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,7 +1,15 @@
-from tests.models import Location, Permission, Group, User
+from tests.models import Location, Permission, Group, User, Cat
 from dynamic_rest.serializers import DynamicModelSerializer
 from dynamic_rest.serializers import DynamicEphemeralSerializer
 from dynamic_rest.fields import DynamicRelationField, CountField, DynamicField
+
+
+class CatSerializer(DynamicModelSerializer):
+
+    class Meta:
+        model = Cat
+        name = 'cat'
+        deferred_fields = ('home', 'backup_home', 'hunting_grous')
 
 
 class LocationSerializer(DynamicModelSerializer):
@@ -9,7 +17,10 @@ class LocationSerializer(DynamicModelSerializer):
     class Meta:
         model = Location
         name = 'location'
-        fields = ('id', 'name', 'users', 'user_count', 'address', 'metadata')
+        fields = (
+            'id', 'name', 'users', 'user_count', 'address', 'metadata',
+            'cats', 'friendly_cats', 'bad_cats'
+        )
 
     users = DynamicRelationField(
         'UserSerializer',
@@ -19,6 +30,12 @@ class LocationSerializer(DynamicModelSerializer):
     user_count = CountField('users', required=False, deferred=True)
     address = DynamicField(source='blob', required=False, deferred=True)
     metadata = DynamicField(deferred=True, required=False)
+    cats = DynamicRelationField(
+        'CatSerializer', source='cat_set', many=True, deferred=True)
+    friendly_cats = DynamicRelationField(
+        'CatSerializer', many=True, deferred=True)
+    bad_cats = DynamicRelationField(
+        'CatSerializer', source='annoying_cats', many=True, deferred=True)
 
 
 class PermissionSerializer(DynamicModelSerializer):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -498,6 +498,17 @@ class TestLocationsAPI(APITestCase):
         content = json.loads(response.content)
         self.assertEqual(1, len(content['locations']))
 
+    def testCatFilters(self):
+        """Tests various filter rewrite scenarios"""
+        urls = [
+            '/locations/?filter{cats}=1',
+            '/locations/?filter{friendly_cats}=1',
+            '/locations/?filter{bad_cats}=1'
+        ]
+        for url in urls:
+            response = self.client.get(url)
+            self.assertEqual(200, response.status_code)
+
 
 class TestUserLocationsAPI(APITestCase):
     """


### PR DESCRIPTION
@aleontiev - Not sure how I missed this, but Django requires different names for accessing vs filtering for remote fields. E.g. `location.user_set.all()` to retrieve, but `Location.objects.filter(user=1)` to filter. Updated the rewrite logic to strip off `_set` when filtering on remote fields.
