### PR TITLE
Adding `.distinct()` to queryset, post-filtering

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -304,4 +304,4 @@ class DynamicFilterBackend(BaseFilterBackend):
             serializer=serializer)
         if q:
             queryset = queryset.filter(q)
-        return queryset.prefetch_related(*prefetch_related.values())
+        return queryset.prefetch_related(*prefetch_related.values()).distinct()


### PR DESCRIPTION
Fixes a bug where certain filters cause results to come back in duplicate (or worse).

@aleontiev It's just the fix we discussed.  Do I need to change something somewhere, or add a tag, or something along those lines, so we can more easily update `requirements.txt` in vishnu-backend?
