### PR TITLE
metadata updates: add resource names, use plural name for related_to

### DIFF
--- a/dynamic_rest/metadata.py
+++ b/dynamic_rest/metadata.py
@@ -24,6 +24,10 @@ class DynamicMetadata(SimpleMetadata):
         metadata['features'] = getattr(view, 'features', [])
         if hasattr(view, 'get_serializer'):
             serializer = view.get_serializer(dynamic=False)
+            if hasattr(serializer, 'get_name'):
+                metadata['resource_name'] = serializer.get_name()
+            if hasattr(serializer, 'get_plural_name'):
+                metadata['resource_name_plural'] = serializer.get_plural_name()
         metadata['properties'] = self.get_serializer_info(serializer)
         return metadata
 
@@ -52,7 +56,7 @@ class DynamicMetadata(SimpleMetadata):
             many = True
         if isinstance(field, ModelSerializer):
             type = 'many' if many else 'one'
-            field_info['related_to'] = field.get_name()
+            field_info['related_to'] = field.get_plural_name()
         else:
             type = self.label_lookup[field]
 


### PR DESCRIPTION
Some minor OPTIONS response changes as requested by @jacobtopper who's spiking on code-generation based on the metadata. Currently, the metadata `name` field shows the API name, (e.g. "Users List") so this adds canonical resource names. Also, the field `related_to` attribute will use the plural name, which makes it easier to infer the corresponding endpoint (I'm not aware of anyone else using this data so I think it's safe to change).
