### PR TITLE
use global directory for root view

### DIFF
--- a/dynamic_rest/renderers.py
+++ b/dynamic_rest/renderers.py
@@ -1,55 +1,16 @@
 from rest_framework.renderers import BrowsableAPIRenderer
-from rest_framework.reverse import reverse
 
 
 class DynamicBrowsableAPIRenderer(BrowsableAPIRenderer):
 
     def get_context(self, data, media_type, context):
+        from dynamic_rest.routers import get_directory
+
         context = super(DynamicBrowsableAPIRenderer, self).get_context(
             data,
             media_type,
             context
         )
         request = context['request']
-        context['directory'] = self.get_directory(request)
+        context['directory'] = get_directory(request)
         return context
-
-    def get_directory(self, request):
-        """Get API directory as a nested list of lists."""
-        from dynamic_rest.routers import directory
-
-        def get_url(url):
-            return reverse(url) if url else url
-
-        def is_active_url(path, url):
-            return path.startswith(url) if url else False
-
-        path = request.path
-        directory_list = []
-        sort_key = lambda r: r[0]
-        # TODO(ant): support arbitrarily nested
-        # structure, for now it is capped at a single level
-        # for UX reasons
-        for group_name, endpoints in sorted(
-            directory.iteritems(),
-            key=sort_key
-        ):
-            endpoints_list = []
-            for endpoint_name, endpoint in sorted(
-                endpoints.iteritems(),
-                key=sort_key
-            ):
-                if endpoint_name == '_url':
-                    continue
-                endpoint_url = get_url(endpoint.get('_url', None))
-                active = is_active_url(path, endpoint_url)
-                endpoints_list.append(
-                    (endpoint_name, endpoint_url, [], active)
-                )
-
-            url = get_url(endpoints.get('_url', None))
-            active = is_active_url(path, url)
-            directory_list.append(
-                (group_name, url, endpoints_list, active)
-            )
-        return directory_list


### PR DESCRIPTION
Addressed the issue @jacobtopper noticed in https://altschool.atlassian.net/browse/ALTOS-1995 wherein the root directory does not list out Apollo's endpoints, only Vishnu's endpoints.

I first tried to address this in Vishnu by creating a shared router used by the various apps, but ended up running into issues. This seems like a more reliable fix and keeps the use of a directory singleton isolated to DREST.

![screen shot 2015-11-02 at 10 40 23 am](https://cloud.githubusercontent.com/assets/1815440/10886011/2a6cf792-814e-11e5-8922-edd836d140fb.png)
