### PR TITLE
Change default `links` format to be resource-relative

### DIFF
--- a/dynamic_rest/serializer_helpers.py
+++ b/dynamic_rest/serializer_helpers.py
@@ -14,9 +14,7 @@ def merge_link_object(serializer, data, instance):
             continue
 
         # Default to DREST-generated relation endpoints.
-        link = getattr(field, 'link', "/%s/%s/%s/" % (
-            serializer.get_plural_name(),
-            instance.pk,
+        link = getattr(field, 'link', "%s/" % (
             name
         ))
         if callable(link):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -813,7 +813,7 @@ class TestLinks(APITestCase):
 
         # test for default link (auto-generated relation endpoint)
         # Note that the pluralized name is used rather than the full prefix.
-        self.assertEqual(cat['links']['foobar'], '/cats/1/foobar/')
+        self.assertEqual(cat['links']['foobar'], 'foobar/')
 
         # test for dynamically generated link URL
         cat1 = Cat.objects.get(pk=1)


### PR DESCRIPTION
Does what it says on the box.

Going to tag this as a WIP, though, until it gets approved.  Mostly just opening this for documentation purposes for an upcoming `vishnu-backend` PR.

Note that this duplicates the work done in the branch `fix/relative-links-urls`... :cry: 