### PR TITLE
fix DNE exception in links endpoint

### DIFF
--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import QueryDict
 from django.utils.datastructures import MergeDict
 
@@ -309,7 +310,13 @@ class WithDynamicViewSetMixin(object):
         # Serialize the related data. Use the field's serializer to ensure
         # it's configured identically to the sideload case.
         serializer = field.serializer
-        serializer.instance = getattr(obj, field.source)
+        try:
+            # TODO(ryo): Probably should use field.get_attribute() but that
+            #            seems to break a bunch of things. Investigate later.
+            serializer.instance = getattr(obj, field.source)
+        except ObjectDoesNotExist:
+            return Response("Does not exist", status=404)
+
         return Response(serializer.data)
 
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -133,8 +133,15 @@ class UserSerializer(DynamicModelSerializer):
             'last_name',
             'display_name',
             'thumbnail_url',
-            'number_of_cats')
-        deferred_fields = ('last_name', 'display_name', 'thumbnail_url')
+            'number_of_cats',
+            'profile'
+        )
+        deferred_fields = (
+            'last_name',
+            'display_name',
+            'profile',
+            'thumbnail_url'
+        )
 
     location = DynamicRelationField('LocationSerializer')
     permissions = DynamicRelationField(
@@ -149,6 +156,10 @@ class UserSerializer(DynamicModelSerializer):
     )
     number_of_cats = DynamicMethodField(
         requires=['location.cat_set.*'],
+        deferred=True
+    )
+    profile = DynamicRelationField(
+        'ProfileSerializer',
         deferred=True
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -411,6 +411,7 @@ class TestUsersAPI(APITestCase):
                     "display_name": None,
                     "thumbnail_url": None,
                     "number_of_cats": 1,
+                    "profile": None
                     }
             })
 
@@ -860,6 +861,15 @@ class TestLinks(APITestCase):
             content_type='application/json'
         )
         self.assertEqual(200, r.status_code)
+
+    def test_one_to_one_dne(self):
+        user = User.objects.create(name='foo', last_name='bar')
+
+        url = '/users/%s/profile/' % user.pk
+        r = self.client.get(url)
+        self.assertEqual(404, r.status_code)
+        # Check error message to differentiate from a routing error 404
+        self.assertEqual('"Does not exist"', r.content)
 
 
 class TestDogsAPI(APITestCase):


### PR DESCRIPTION
Fix handling of DoesNotExist error that's raised when the links endpoint for a non-existent o2o relation is accessed.
