### PR TITLE
valid but empty relation to return 200

### DIFF
--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -315,7 +315,11 @@ class WithDynamicViewSetMixin(object):
             #            seems to break a bunch of things. Investigate later.
             serializer.instance = getattr(obj, field.source)
         except ObjectDoesNotExist:
-            return Response("Does not exist", status=404)
+            # See:
+            # http://jsonapi.org/format/#fetching-relationships-responses-404
+            # This is a case where the "link URL exists but the relationship
+            # is empty" and therefore must return a 200.
+            return Response({}, status=200)
 
         return Response(serializer.data)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -868,9 +868,10 @@ class TestLinks(APITestCase):
 
         url = '/users/%s/profile/' % user.pk
         r = self.client.get(url)
-        self.assertEqual(404, r.status_code)
+        self.assertEqual(200, r.status_code)
         # Check error message to differentiate from a routing error 404
-        self.assertEqual('"Does not exist"', r.content)
+        content = json.loads(r.content)
+        self.assertEqual({}, content)
 
     def test_ephemeral_object_link(self):
 


### PR DESCRIPTION
According to the [JSON API spec](http://jsonapi.org/format/#fetching-relationships-responses-404): "If a relationship link URL exists but the relationship is empty, then 200 OK MUST be returned", so we might as well follow that pattern.
