### PR TITLE
Fix nested serializer inconsistency bug.

### DIFF
--- a/dynamic_rest/wrappers.py
+++ b/dynamic_rest/wrappers.py
@@ -53,21 +53,3 @@ class _TaggedPlainDict(TaggedDict, dict):
 
 class _TaggedOrderedDict(TaggedDict, OrderedDict):
     pass
-
-
-def hash_dict(obj):
-    """Hash a dict (which aren't normally hashable)."""
-
-    def _convert(o):
-        # Recursively convert to hashable types
-        if isinstance(o, dict):
-            o = o.items()
-        if hasattr(o, '__iter__'):
-            out = []
-            for i in o:
-                out.append(_convert(i))
-            return frozenset(out)
-        else:
-            return o
-
-    return hash(_convert(obj))

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,6 +26,11 @@ class Cat(models.Model):
         related_name='annoying_cats',
         related_query_name='getoffmylawn'
     )
+    parent = models.ForeignKey(
+        'Cat',
+        null=True,
+        blank=True,
+        related_name='kittens')
 
 
 class Dog(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -26,12 +26,13 @@ class CatSerializer(DynamicModelSerializer):
         'LocationSerializer', link=backup_home_link)
     foobar = DynamicRelationField(
         'LocationSerializer', source='hunting_grounds', many=True)
+    parent = DynamicRelationField('CatSerializer')
 
     class Meta:
         model = Cat
         name = 'cat'
-        fields = ('id', 'name', 'home', 'backup_home', 'foobar')
-        deferred_fields = ('home', 'backup_home', 'foobar')
+        fields = ('id', 'name', 'home', 'backup_home', 'foobar', 'parent')
+        deferred_fields = ('home', 'backup_home', 'foobar', 'parent')
 
 
 class LocationSerializer(DynamicModelSerializer):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -643,3 +643,33 @@ class TestSerializerCaching(TestCase):
         s.parent = s  # Create cycle.
 
         self.assertIsNone(s.fields['home'].root_serializer)
+
+    def test_root_serializer_trickledown_request_fields(self):
+        s = CatSerializer(
+            request_fields=True
+        )
+
+        self.assertIsNotNone(s.get_all_fields()['home'].serializer)
+
+    def test_recursive_serializer(self):
+        s = LocationSerializer(
+            request_fields={
+                'cats': {
+                    'parent': {
+                        'parent': True
+                    }
+                }
+            }
+        )
+
+        cats_field = s.get_all_fields()['cats']
+
+        l1 = cats_field.serializer.child  # .child because list
+        l2 = l1.get_all_fields()['parent'].serializer
+        l3 = l2.get_all_fields()['parent'].serializer
+        l4 = l3.get_all_fields()['parent'].serializer
+        self.assertIsNot(l2, l3)
+
+        # l3 and l4 should be same cached instance because both have
+        # request_fields=True (l3 by inheritence, l4 by default)
+        self.assertIs(l3, l4)


### PR DESCRIPTION
Moves `request_fields` and other attribute propagation for nested serializers out of the parent serializer and into `field.get_serializer()`. This ensures consistent behavior of child serializers and concentrates child serializer configuration into one place (as opposed to constructing them in one place and modifying them in another). See https://github.com/AltSchool/dynamic-rest/pull/59 for more context.
