### PR TITLE
remove links for included single-relation fields

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -274,7 +274,7 @@ class WithDynamicSerializerMixin(DynamicSerializerBase):
                     # Skip included single relations
                     # TODO: Use links, when we can generate canonical URLs
                     name in self.fields
-                    and not field.serializer.many
+                    and not getattr(field.serializer, 'many', False)
                 )
             }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -994,7 +994,6 @@ class TestLinks(APITestCase):
         r = self.client.get('/v2/cats/%s/?include[]=foobar' % self.cat.pk)
         self.assertEqual(200, r.status_code)
         content = json.loads(r.content.decode('utf-8'))
-        print json.dumps(content, indent=2)
         cat = content['cat']
         self.assertTrue('foobar' in cat)
         self.assertTrue('foobar' in cat['links'])


### PR DESCRIPTION
This change removes links for included single-relation fields as a temporary workaround for double-fetching behavior in Ember Data. The fact that the links differ from the canonical resource URL seems to be causing this double-fetching. The correct long term solution is for links for single-resources to be the canonical URL (e.g. `/<namespace>/<resource>/<pk>/`) but we don't have a reliable way of generating those, so for now, we'll remove the links and expect the client to fetch those resources using the PK that is returned in the data. For deferred fields, links are still generated since clients will have no other way of traversing that relation.

See: https://altschool.atlassian.net/browse/ALTOS-4662
