### PR TITLE
new router API to allow DREST to map/generate canonical resource URLs

### DIFF
--- a/dynamic_rest/meta.py
+++ b/dynamic_rest/meta.py
@@ -72,3 +72,10 @@ def is_field_remote(model, field_name):
 
     model_field = get_model_field(model, field_name)
     return isinstance(model_field, (ManyToManyField, RelatedObject))
+
+
+def get_model_table(model):
+    try:
+        return model._meta.db_table
+    except:
+        return None

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -8,6 +8,7 @@ from rest_framework.reverse import reverse
 from rest_framework.routers import DefaultRouter, Route, replace_methodname
 
 from dynamic_rest.fields import DynamicRelationField
+from dynamic_rest.meta import get_model_table
 
 directory = {}
 resource_map = {}
@@ -180,36 +181,42 @@ class DynamicRouter(DefaultRouter):
             'viewset': viewset
         }
 
-    def get_canonical_path(self, resource, pk=None):
+    @staticmethod
+    def get_canonical_path(resource_key, pk=None):
         """
         Return canonical resource path.
 
         Arguments:
-            resource - Canonical resource name (i.e. Serializer.get_name()).
+            resource_key - Canonical resource key
+                           i.e. Serializer.get_resource_key().
             pk - (Optional) Object's primary key for a single-resource URL.
         Returns: Absolute URL as string.
         """
 
-        if resource not in resource_map:
+        if resource_key not in resource_map:
             # Note: Maybe raise?
             return None
 
-        base_path = '/' + resource_map[resource]['path']
+        base_path = '/' + resource_map[resource_key]['path']
         if pk:
-            return base_path + '/%s/' % pk
+            return '%s/%s/' % (base_path, pk)
         else:
             return base_path
 
     @staticmethod
-    def get_canonical_serializer(resource_key):
+    def get_canonical_serializer(resource_key, model=None):
         """
         Return canonical serializer for a given resource name.
 
         Arguments:
             resource_key - Resource key, usually DB table for model-based
                            resources, otherwise the plural name.
+            model - (Optional) Model class to look up by.
         Returns: serializer class
         """
+
+        if model:
+            resource_key = get_model_table(model)
 
         if resource_key not in resource_map:
             return None

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -183,6 +183,7 @@ class DynamicRouter(DefaultRouter):
         Arguments:
             resource - Canonical resource name (i.e. Serializer.get_name()).
             pk - (Optional) Object's primary key for a single-resource URL.
+        Returns: Absolute URL as string.
         """
 
         if resource not in resource_map:
@@ -194,6 +195,20 @@ class DynamicRouter(DefaultRouter):
             return base_path + '/%s/' % pk
         else:
             return base_path
+
+    def get_canonical_serializer(self, resource):
+        """
+        Return canonical serializer for a given resource name.
+
+        Arguments:
+            resource - Resource name as string.
+        Returns: serializer class
+        """
+
+        if resource not in resource_map:
+            return None
+
+        return resource_map[resource]['viewset'].serializer_class
 
     def get_routes(self, viewset):
         """

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -13,6 +13,7 @@ from dynamic_rest.bases import DynamicSerializerBase
 from dynamic_rest.conf import settings
 from dynamic_rest.fields import DynamicRelationField
 from dynamic_rest.links import merge_link_object
+from dynamic_rest.meta import get_model_table
 from dynamic_rest.processors import SideloadingProcessor
 from dynamic_rest.tagged import tag_dict
 
@@ -22,7 +23,7 @@ class WithResourceKeyMixin(object):
         """Return canonical resource key, usually the DB table name."""
         model = self.get_model()
         if model:
-            return model._meta.db_table
+            return get_model_table(model)
         else:
             return self.get_name()
 

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -17,7 +17,17 @@ from dynamic_rest.processors import SideloadingProcessor
 from dynamic_rest.tagged import tag_dict
 
 
-class DynamicListSerializer(serializers.ListSerializer):
+class WithResourceKeyMixin(object):
+    def get_resource_key(self):
+        """Return canonical resource key, usually the DB table name."""
+        model = self.get_model()
+        if model:
+            return model._meta.db_table
+        else:
+            return self.get_name()
+
+
+class DynamicListSerializer(WithResourceKeyMixin, serializers.ListSerializer):
     """Custom ListSerializer class.
 
     This implementation delegates DREST-specific methods to
@@ -66,7 +76,7 @@ class DynamicListSerializer(serializers.ListSerializer):
         return self._sideloaded_data
 
 
-class WithDynamicSerializerMixin(DynamicSerializerBase):
+class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
     """Base class for DREST serializers.
 
     This class provides support for dynamic field inclusions/exclusions.

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,44 @@
+from rest_framework.test import APITestCase
+
+from dynamic_rest.meta import get_model_table
+from dynamic_rest.routers import DynamicRouter
+from tests.models import Dog
+from tests.serializers import CatSerializer, DogSerializer
+from tests.urls import urlpatterns  # noqa  force route registration
+
+
+class TestDynamicRouter(APITestCase):
+
+    def test_get_canonical_path(self):
+        rsrc_key = DogSerializer().get_resource_key()
+        self.assertEqual(
+            '/dogs',
+            DynamicRouter.get_canonical_path(rsrc_key)
+        )
+
+    def test_get_canonical_path_with_pk(self):
+        rsrc_key = DogSerializer().get_resource_key()
+        self.assertEqual(
+            '/dogs/1/',
+            DynamicRouter.get_canonical_path(rsrc_key, pk='1')
+        )
+
+    def test_get_canonical_path_with_keyspace(self):
+        rsrc_key = CatSerializer().get_resource_key()
+        self.assertEqual(
+            '/v2/cats',
+            DynamicRouter.get_canonical_path(rsrc_key)
+        )
+
+    def test_get_canonical_serializer(self):
+        rsrc_key = get_model_table(Dog)
+        self.assertEqual(
+            DogSerializer,
+            DynamicRouter.get_canonical_serializer(rsrc_key)
+        )
+
+    def test_get_canonical_serializer_by_model(self):
+        self.assertEqual(
+            DogSerializer,
+            DynamicRouter.get_canonical_serializer(None, model=Dog)
+        )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,16 +4,16 @@ from dynamic_rest.routers import DynamicRouter
 from tests import viewsets
 
 router = DynamicRouter()
-router.register(r'users', viewsets.UserViewSet)
-router.register(r'groups', viewsets.GroupViewSet)
-router.register(r'profiles', viewsets.ProfileViewSet)
-router.register(r'locations', viewsets.LocationViewSet)
+router.register_resource(viewsets.UserViewSet)
+router.register_resource(viewsets.GroupViewSet)
+router.register_resource(viewsets.ProfileViewSet)
+router.register_resource(viewsets.LocationViewSet)
 
-router.register(r'cats', viewsets.CatViewSet)
-router.register(r'dogs', viewsets.DogViewSet)
-router.register(r'horses', viewsets.HorseViewSet)
-router.register(r'zebras', viewsets.ZebraViewSet)
-router.register(r'user_locations', viewsets.UserLocationViewSet)
+router.register_resource(viewsets.CatViewSet)
+router.register_resource(viewsets.DogViewSet)
+router.register_resource(viewsets.HorseViewSet)
+router.register_resource(viewsets.ZebraViewSet)
+router.register_resource(viewsets.UserLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
 router.register(r'v2/cats', viewsets.CatViewSet)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,7 +13,7 @@ router.register_resource(viewsets.CatViewSet)
 router.register_resource(viewsets.DogViewSet)
 router.register_resource(viewsets.HorseViewSet)
 router.register_resource(viewsets.ZebraViewSet)
-router.register_resource(viewsets.UserLocationViewSet)
+router.register(r'user_locations', viewsets.UserLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
 router.register(r'v2/cats', viewsets.CatViewSet)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,14 +9,14 @@ router.register_resource(viewsets.GroupViewSet)
 router.register_resource(viewsets.ProfileViewSet)
 router.register_resource(viewsets.LocationViewSet)
 
-router.register_resource(viewsets.CatViewSet)
+router.register(r'cats', viewsets.CatViewSet)
 router.register_resource(viewsets.DogViewSet)
 router.register_resource(viewsets.HorseViewSet)
 router.register_resource(viewsets.ZebraViewSet)
 router.register(r'user_locations', viewsets.UserLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
-router.register(r'v2/cats', viewsets.CatViewSet)
+router.register_resource(viewsets.CatViewSet, namespace='v2')  # canonical
 router.register(r'v1/user_locations', viewsets.UserLocationViewSet)
 
 urlpatterns = patterns(


### PR DESCRIPTION
This PR adds a new `router.register_resource()` API for registering the canonical resource URL. It automatically generates the path using the viewset's serializer's resource name to enforce our existing naming convention. The router then internally maintains a reverse map so we can take a resource name and generate a URL with confidence, as well as determine a resource's canonical serializer.

TODO:

- [x] Tests
- [ ] Update docs