### PR TITLE
Fix/recursive prefetch

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -351,11 +351,15 @@ class DynamicFilterBackend(BaseFilterBackend):
         """Add internal (required) prefetches to a prefetch dictionary."""
         paths = requirements.get_paths()
         for path in paths:
-            # Remove last segment, which indicates a field name or wildcard.
-            # For example, {model_a : {model_b : {field_c}}
-            # should be prefetched as a__b
-            prefetch_path = path[:-1]
-            key = '__'.join(prefetch_path)
+            if '__' in path[0]:
+                key = path[0]
+            else:
+                # Remove last segment, which indicates a field name or
+                # wildcard.
+                # For example, {model_a : {model_b : {field_c}}
+                # should be prefetched as a__b
+                prefetch_path = path[:-1]
+                key = '__'.join(prefetch_path)
             if key:
                 prefetches[key] = key
                 if self.DEBUG:

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -144,6 +144,7 @@ class UserSerializer(DynamicModelSerializer):
             'display_name',
             'thumbnail_url',
             'number_of_cats',
+            'number_of_katz',
             'number_of_alive_cats',
             'profile'
         )
@@ -170,6 +171,10 @@ class UserSerializer(DynamicModelSerializer):
         requires=['location.cat_set.*'],
         deferred=True
     )
+    number_of_katz = DynamicMethodField(
+        requires=['location__cat_set'],
+        deferred=True
+    )
     number_of_alive_cats = DynamicMethodField(
         requires=['location.cats.*'],
         deferred=True
@@ -181,6 +186,9 @@ class UserSerializer(DynamicModelSerializer):
 
     def get_number_of_cats(self, user):
         return len(user.location.cat_set.all())
+
+    def get_number_of_katz(self, user):
+        return self.get_number_of_cats(user)
 
     def get_number_of_alive_cats(self, user):
         # NOTE: This field requires the `location.cats` serializer

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -483,6 +483,7 @@ class TestUsersAPI(APITestCase):
                     "display_name": None,
                     "thumbnail_url": None,
                     "number_of_cats": 1,
+                    "number_of_katz": 1,
                     "number_of_alive_cats": 1,
                     "profile": None
                 }
@@ -929,6 +930,19 @@ class TestLocationsAPI(APITestCase):
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(200, response.status_code)
+
+    def test_requires_hack(self):
+        # This does N+1 queries on cats
+        # See related test against Django in test_prefetch.py
+        with self.assertNumQueries(8):
+            url = '/locations/?include[]=users.number_of_cats'
+            self.client.get(url)
+
+        with self.assertNumQueries(5):
+            # TODO: There's 1 extra query (cats get queried twice) but it's
+            #       not an N+1 situation.
+            url = '/locations/?include[]=users.number_of_katz'
+            self.client.get(url)
 
 
 class TestRelationsAPI(APITestCase):

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -1,14 +1,7 @@
 from django.db.models import Prefetch
 from django.test import TestCase
 
-from tests.models import (
-    A,
-    B,
-    C,
-    D,
-    Location,
-    User
-)
+from tests.models import A, B, C, D, Location, User
 from tests.setup import create_fixture
 
 


### PR DESCRIPTION
The change in `requires` behavior in https://github.com/AltSchool/dynamic-rest/pull/84 surfaced a Django bug (also see https://github.com/AltSchool/vishnu-backend/pull/2396#issuecomment-190592145) that crops up when the prefetch tree is recursive.

This PR further modifies `requires` to support a workaround in scenarios where this bug is likely to be triggered. This is a really hacky solution, but I'd rather not dive back into the Django prefetch code right now...