### PR TITLE
support for generic relation fields

### DIFF
--- a/dynamic_rest/content_type_field.py
+++ b/dynamic_rest/content_type_field.py
@@ -1,0 +1,56 @@
+import traceback
+
+from dynamic_rest.routers import DynamicRouter
+from dynamic_rest.fields import DynamicField
+
+
+class DynamicContentTypeField(DynamicField):
+
+    def __init__(
+        self,
+        object_field=None,
+        type_field=None,
+        id_field=None,
+        *args, **kwargs
+    ):
+        # NOTE: object_field should be same as `source`, except `source`
+        #       isn't reliably available until this field is bound().
+        if not object_field:
+            raise Exception(
+                'DynamicContentTypeField requires `object_field` kwarg'
+            )
+
+        # Infer type field and id field from object_field if not explicitly set
+        type_field = type_field or object_field + '_type'
+        id_field = id_field or object_field + '_id'
+
+        # Inject `requires` so required fields get prefetched properly.
+        # TODO: It seems like we should be able to require the type and
+        #       id fields, but that seems to conflict with some internal
+        #       Django magic. Disabling `.only()` by requiring '*' seem
+        #       to work more reliably...
+        kwargs['requires'] = kwargs.pop('requires', []) + [
+            object_field + '.*',
+            '*'
+        ]
+        kwargs['read_only'] = True
+        super(DynamicContentTypeField, self).__init__(*args, **kwargs)
+
+    def to_representation(self, instance):
+        try:
+            # Fetch related object, determine its type
+            resource_key = instance._meta.db_table
+
+            # Find serializer for that resource type
+            serializer_class = DynamicRouter.get_canonical_serializer(
+                resource_key
+            )
+
+            # TODO: In theory, it is possible to inject require_fields here
+            #       and support field inclusion/exclusion...
+            return serializer_class(context=self.context).to_representation(
+                instance
+            )
+        except:
+            traceback.print_exc()
+            return None

--- a/dynamic_rest/content_type_field.py
+++ b/dynamic_rest/content_type_field.py
@@ -36,15 +36,32 @@ class DynamicContentTypeField(DynamicField):
         kwargs['read_only'] = True
         super(DynamicContentTypeField, self).__init__(*args, **kwargs)
 
+    def id_only(self):
+        if self.parent and self.field_name:
+            parent_request_fields = getattr(
+                self.parent,
+                'request_fields',
+                {}
+            )
+            return parent_request_fields.get(self.field_name)
+
     def to_representation(self, instance):
+
         try:
-            # Fetch related object, determine its type
+            # Determine resource type
             resource_key = instance._meta.db_table
 
             # Find serializer for that resource type
             serializer_class = DynamicRouter.get_canonical_serializer(
                 resource_key
             )
+
+            # TODO: Add support for `id_only()` here.
+            if self.id_only():
+                return {
+                    'type': serializer_class().get_plural_name(),
+                    'id': instance.pk
+                }
 
             # TODO: In theory, it is possible to inject require_fields here
             #       and support field inclusion/exclusion...

--- a/dynamic_rest/content_type_field.py
+++ b/dynamic_rest/content_type_field.py
@@ -1,7 +1,7 @@
 import traceback
 
-from dynamic_rest.routers import DynamicRouter
 from dynamic_rest.fields import DynamicField
+from dynamic_rest.routers import DynamicRouter
 
 
 class DynamicContentTypeField(DynamicField):

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -183,6 +183,7 @@ class DynamicRouter(DefaultRouter):
         Arguments:
             resource - Canonical resource name (i.e. Serializer.get_name()).
             pk - (Optional) Object's primary key for a single-resource URL.
+        Returns: Absolute URL as string.
         """
 
         if resource not in resource_map:
@@ -194,6 +195,20 @@ class DynamicRouter(DefaultRouter):
             return base_path + '/%s/' % pk
         else:
             return base_path
+
+    def get_canonical_serializer(self, resource):
+        """
+        Return canonical serializer for a given resource name.
+
+        Arguments:
+            resource - Resource name as string.
+        Returns: serializer class
+        """
+
+        if resource not in resource_map:
+            return None
+
+        return resource_map[resource]['viewset'].serializer_class
 
     def get_routes(self, viewset):
         """

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -17,7 +17,17 @@ from dynamic_rest.processors import SideloadingProcessor
 from dynamic_rest.tagged import tag_dict
 
 
-class DynamicListSerializer(serializers.ListSerializer):
+class WithResourceKeyMixin(object):
+    def get_resource_key(self):
+        """Return canonical resource key, usually the DB table name."""
+        model = self.get_model()
+        if model:
+            return model._meta.db_table
+        else:
+            return self.get_name()
+
+
+class DynamicListSerializer(WithResourceKeyMixin, serializers.ListSerializer):
     """Custom ListSerializer class.
 
     This implementation delegates DREST-specific methods to
@@ -66,7 +76,7 @@ class DynamicListSerializer(serializers.ListSerializer):
         return self._sideloaded_data
 
 
-class WithDynamicSerializerMixin(DynamicSerializerBase):
+class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
     """Base class for DREST serializers.
 
     This class provides support for dynamic field inclusions/exclusions.

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,3 @@
 Django>=1.7,<=1.9
 djangorestframework>=3.1.0,<=3.3.0
 inflection==0.3.1
-django-debug-toolbar==1.4

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,3 +1,4 @@
 Django>=1.7,<=1.9
 djangorestframework>=3.1.0,<=3.3.0
 inflection==0.3.1
+django-debug-toolbar==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==1.3.4
 dj-database-url==0.3.0
+django-debug-toolbar==1.4
 flake8==2.4.0
 isort==4.2.2
 pytest-cov==1.8.1

--- a/tests/migrations/0003_auto_20160316_1438.py
+++ b/tests/migrations/0003_auto_20160316_1438.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/tests/migrations/0003_auto_20160316_1438.py
+++ b/tests/migrations/0003_auto_20160316_1438.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0001_initial'),
+        ('tests', '0002_cat_is_dead'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='favorite_pet_id',
+            field=models.TextField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='favorite_pet_type',
+            field=models.ForeignKey(blank=True, to='contenttypes.ContentType', null=True),  # noqa
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='group',
+            name='name',
+            field=models.TextField(unique=True),
+            preserve_default=True,
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,6 @@
-from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 
 
 class User(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 
 
 class User(models.Model):
@@ -8,6 +10,12 @@ class User(models.Model):
     permissions = models.ManyToManyField('Permission', related_name='users')
     # 'related_name' intentionally left unset in location field below:
     location = models.ForeignKey('Location', null=True, blank=True)
+    favorite_pet_type = models.ForeignKey(ContentType, null=True, blank=True)
+    favorite_pet_id = models.TextField(null=True, blank=True)
+    favorite_pet = GenericForeignKey(
+        'favorite_pet_type',
+        'favorite_pet_id',
+    )
 
 
 class Profile(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework.serializers import CharField
 
+from dynamic_rest.content_type_field import DynamicContentTypeField
 from dynamic_rest.fields import (
     CountField,
     DynamicField,
@@ -145,13 +146,18 @@ class UserSerializer(DynamicModelSerializer):
             'thumbnail_url',
             'number_of_cats',
             'number_of_alive_cats',
-            'profile'
+            'profile',
+            'favorite_pet_id',
+            'favorite_pet'
         )
         deferred_fields = (
             'last_name',
             'display_name',
             'profile',
-            'thumbnail_url'
+            'thumbnail_url',
+            'favorite_pet_type',
+            'favorite_pet_id',
+            'favorite_pet',
         )
 
     location = DynamicRelationField('LocationSerializer')
@@ -177,6 +183,11 @@ class UserSerializer(DynamicModelSerializer):
     profile = DynamicRelationField(
         'ProfileSerializer',
         deferred=True
+    )
+    favorite_pet = DynamicContentTypeField(
+        object_field='favorite_pet',
+        type_field='favorite_pet_type',  # not required
+        id_field='favorite_pet_id'  # not required
     )
 
     def get_number_of_cats(self, user):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.auth',
     'django.contrib.sites',
+    'debug_toolbar',
     'tests',
 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -477,6 +477,8 @@ class TestUsersAPI(APITestCase):
                     "id": 5,
                     "name": "test",
                     "permissions": [],
+                    "favorite_pet": None,
+                    "favorite_pet_id": None,
                     "groups": [],
                     "location": 1,
                     "last_name": "last",

--- a/tests/test_content_type_field.py
+++ b/tests/test_content_type_field.py
@@ -19,7 +19,35 @@ class TestContentTypeFieldAPI(APITestCase):
         f.users[2].favorite_pet = f.dogs[1]
         f.users[2].save()
 
-    def test_basic(self):
+    def test_id_only(self):
+        """
+        In the id_only case, the favorite_pet field looks like:
+
+        ```
+            "favorite_animal" : {
+                "type": "cats",
+                "id": "1"
+            }
+        ```
+        """
+        url = (
+            '/users/?include[]=favorite_pet'
+            '&filter{favorite_pet_id.isnull}=false'
+        )
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            all(
+                [_['favorite_pet'] for _ in content['users']]
+            )
+        )
+        self.assertFalse('cats' in content)
+        self.assertFalse('dogs' in content)
+        self.assertTrue('type' in content['users'][0]['favorite_pet'])
+        self.assertTrue('id' in content['users'][0]['favorite_pet'])
+
+    def test_sideload(self):
         url = (
             '/users/?include[]=favorite_pet.'
             '&filter{favorite_pet_id.isnull}=false'

--- a/tests/test_content_type_field.py
+++ b/tests/test_content_type_field.py
@@ -1,0 +1,56 @@
+import json
+
+from rest_framework.test import APITestCase
+
+from tests.setup import create_fixture
+
+
+class TestContentTypeFieldAPI(APITestCase):
+
+    def setUp(self):
+        self.fixture = create_fixture()
+        f = self.fixture
+        f.users[0].favorite_pet = f.cats[0]
+        f.users[0].save()
+
+        f.users[1].favorite_pet = f.cats[1]
+        f.users[1].save()
+
+        f.users[2].favorite_pet = f.dogs[1]
+        f.users[2].save()
+
+    def test_basic(self):
+        url = (
+            '/users/?include[]=favorite_pet.'
+            '&filter{favorite_pet_id.isnull}=false'
+        )
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            all(
+                [_['favorite_pet'] for _ in content['users']]
+            )
+        )
+        self.assertTrue('cats' in content)
+        self.assertEqual(2, len(content['cats']))
+        self.assertTrue('dogs' in content)
+        self.assertEqual(1, len(content['dogs']))
+
+    def test_query_counts(self):
+        # NOTE: Django doesn't seem to prefetch ContentType objects
+        #       themselves, and rather caches internally. That means
+        #       this call could do 5 SQL queries if the Cat and Dog
+        #       ContentType objects haven't been cached.
+        with self.assertNumQueries(3):
+            url = (
+                '/users/?include[]=favorite_pet.'
+                '&filter{favorite_pet_id.isnull}=false'
+            )
+            response = self.client.get(url)
+            self.assertEqual(200, response.status_code)
+
+        with self.assertNumQueries(3):
+            url = '/users/?include[]=favorite_pet.'
+            response = self.client.get(url)
+            self.assertEqual(200, response.status_code)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,16 +4,16 @@ from dynamic_rest.routers import DynamicRouter
 from tests import viewsets
 
 router = DynamicRouter()
-router.register(r'users', viewsets.UserViewSet)
-router.register(r'groups', viewsets.GroupViewSet)
-router.register(r'profiles', viewsets.ProfileViewSet)
-router.register(r'locations', viewsets.LocationViewSet)
+router.register_resource(viewsets.UserViewSet)
+router.register_resource(viewsets.GroupViewSet)
+router.register_resource(viewsets.ProfileViewSet)
+router.register_resource(viewsets.LocationViewSet)
 
-router.register(r'cats', viewsets.CatViewSet)
-router.register(r'dogs', viewsets.DogViewSet)
-router.register(r'horses', viewsets.HorseViewSet)
-router.register(r'zebras', viewsets.ZebraViewSet)
-router.register(r'user_locations', viewsets.UserLocationViewSet)
+router.register_resource(viewsets.CatViewSet)
+router.register_resource(viewsets.DogViewSet)
+router.register_resource(viewsets.HorseViewSet)
+router.register_resource(viewsets.ZebraViewSet)
+router.register_resource(viewsets.UserLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
 router.register(r'v2/cats', viewsets.CatViewSet)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,7 +13,7 @@ router.register_resource(viewsets.CatViewSet)
 router.register_resource(viewsets.DogViewSet)
 router.register_resource(viewsets.HorseViewSet)
 router.register_resource(viewsets.ZebraViewSet)
-router.register_resource(viewsets.UserLocationViewSet)
+router.register(r'user_locations', viewsets.UserLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
 router.register(r'v2/cats', viewsets.CatViewSet)


### PR DESCRIPTION
Builds on router changes in https://github.com/AltSchool/dynamic-rest/pull/85 to add improved support for ContentType fields.

**Supported:**
 * Including/sideloading of polymorphic relations using canonical serializer (if registered)
 * Prefetching (some weirdness around how Django seems to fetch/cache ContentType objects themselves)

**Not supported:**
 * `include[]` and `exclude[]` of fields within related objects (which arguably doesn't make sense anyway)
 * `filter{}` for fields within related objects
 * `filter{}` for ContentType fields themselves, other than with `.isnull` operator

**Output structure (proposed):**
(`user.pet` is the polymorphic relation)

```
{
  "users": [{
    "id": 1,
    "pet": {
      "type": "cats",
      "id": 1
    }
  },{
    "id": 2,
    "pet": {
      "type": "dogs",
      "id": 1
    }
  }],
  "cats": [{
    "id": 1,
     ...
  }],
  "dogs": [{
    "id": 1,
     ...
  }]
}
```

**Todo:**
 - [ ] Ratify approach and whether or not this makes sense to add
 - [ ] Ratify output format
 - [ ] When sideloading, parent object should include `type` instead of just the ID
 - [ ] Add some sensible default behavior for when there's no registered serializer for sideloaded resource.
 - [ ] Support for polymorphic many relations?
