### PR TITLE
Fix/serializer name optimization

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -215,12 +215,15 @@ class WithDynamicSerializerMixin(DynamicSerializerBase):
         The name can be defined on the Meta class or will be generated
         automatically from the model name.
         """
-        class_name = getattr(cls.get_model(), '__name__', None)
-        return getattr(
-            cls.Meta,
-            'name',
-            inflection.underscore(class_name) if class_name else None
-        )
+        if not hasattr(cls.Meta, 'name'):
+            class_name = getattr(cls.get_model(), '__name__', None)
+            setattr(
+                cls.Meta,
+                'name',
+                inflection.underscore(class_name) if class_name else None
+            )
+
+        return cls.Meta.name
 
     @classmethod
     def get_plural_name(cls):
@@ -230,11 +233,13 @@ class WithDynamicSerializerMixin(DynamicSerializerBase):
         If the plural name is not defined,
         the pluralized form of the name will be returned.
         """
-        return getattr(
-            cls.Meta,
-            'plural_name',
-            inflection.pluralize(cls.get_name())
-        )
+        if not hasattr(cls.Meta, 'plural_name'):
+            setattr(
+                cls.Meta,
+                'plural_name',
+                inflection.pluralize(cls.get_name())
+            )
+        return cls.Meta.plural_name
 
     def get_all_fields(self):
         """Returns the entire serializer field set.

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -706,10 +706,16 @@ class TestMeta(TestCase):
 
     def test_default_name(self):
         serializer = DogSerializer()
+        if hasattr(serializer.Meta, 'name'):
+            # bust cached value
+            del(serializer.Meta.name)
         self.assertFalse(hasattr(serializer.Meta, 'name'))
         self.assertEqual('dog', serializer.get_name())
 
     def test_default_plural_name(self):
         serializer = DogSerializer()
+        if hasattr(serializer.Meta, 'plural_name'):
+            # bust cached value
+            del(serializer.Meta.plural_name)
         self.assertFalse(hasattr(serializer.Meta, 'plural_name'))
         self.assertEqual('dogs', serializer.get_plural_name())


### PR DESCRIPTION
Re-computing the plural name is apparently surprisingly costly. This PR caches the value so we only compute it once.

<img width="967" alt="screen shot 2016-03-28 at 9 50 54 am" src="https://cloud.githubusercontent.com/assets/172724/14092596/f5cb5556-f4fc-11e5-8219-471ce1b5a4b7.png">
