### PR TITLE
Feature: DynamicGenericRelationField write flows

### DIFF
--- a/dynamic_rest/fields/generic.py
+++ b/dynamic_rest/fields/generic.py
@@ -22,7 +22,6 @@ class DynamicGenericRelationField(
 
         super(DynamicGenericRelationField, self).__init__(*args, **kwargs)
         self.embed = embed
-        self.read_only = False
 
     def bind(self, field_name, parent):
         super(DynamicGenericRelationField, self).bind(field_name, parent)
@@ -84,7 +83,7 @@ class DynamicGenericRelationField(
             # We want the pk to be represented as an object with type,
             # rather than just the ID.
             pk_value = self.get_pk_object(
-                serializer_class().get_name(),
+                serializer_class.get_name(),
                 instance.pk
             )
             if self.id_only():

--- a/dynamic_rest/fields/generic.py
+++ b/dynamic_rest/fields/generic.py
@@ -84,7 +84,7 @@ class DynamicGenericRelationField(
             # We want the pk to be represented as an object with type,
             # rather than just the ID.
             pk_value = self.get_pk_object(
-                serializer_class().get_plural_name(),
+                serializer_class().get_name(),
                 instance.pk
             )
             if self.id_only():
@@ -117,13 +117,12 @@ class DynamicGenericRelationField(
         model_name = data.get('type', None)
         model_id = data.get('id', None)
         if model_name and model_id:
-            # model_name = inflection.singularize(model_name)
             serializer_class = DynamicRouter.get_canonical_serializer(
                 resource_key=None,
                 resource_name=model_name
             )
             if serializer_class:
                 model = serializer_class.get_model()
-                return model.objects.get(id=model_id)
+                return model.objects.get(id=model_id) if model else None
 
         return None

--- a/dynamic_rest/fields/generic.py
+++ b/dynamic_rest/fields/generic.py
@@ -22,7 +22,7 @@ class DynamicGenericRelationField(
 
         super(DynamicGenericRelationField, self).__init__(*args, **kwargs)
         self.embed = embed
-        self.read_only = True
+        self.read_only = False
 
     def bind(self, field_name, parent):
         super(DynamicGenericRelationField, self).bind(field_name, parent)
@@ -112,3 +112,18 @@ class DynamicGenericRelationField(
             # TODO: Remove once we have more confidence.
             traceback.print_exc()
             return None
+
+    def to_internal_value(self, data):
+        model_name = data.get('type', None)
+        model_id = data.get('id', None)
+        if model_name and model_id:
+            # model_name = inflection.singularize(model_name)
+            serializer_class = DynamicRouter.get_canonical_serializer(
+                resource_key=None,
+                resource_name=model_name
+            )
+            if serializer_class:
+                model = serializer_class.get_model()
+                return model.objects.get(id=model_id)
+
+        return None

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -181,6 +181,23 @@ class DynamicRouter(DefaultRouter):
             'path': base_path,
             'viewset': viewset
         }
+
+        # Make sure the resource name isn't registered, either
+        # TODO: Think of a better way to clean this up, there's a lot of
+        # duplicated effort here, between `resource_name` and `resource_key`
+        # This resource name -> key mapping is currently only used by
+        # the DynamicGenericRelationField
+        if resource_name in resource_name_map:
+            resource_key = resource_name_map[resource_name]
+            raise Exception(
+                "The resource name '%s' has already been mapped to '%s'."
+                " A resource name can only be used once." % (
+                    resource_name,
+                    resource_map[resource_key]['path']
+                )
+            )
+
+        # map the resource name to the resource key for easier lookup
         resource_name_map[resource_name] = resource_key
 
     @staticmethod

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -146,7 +146,8 @@ class DynamicRouter(DefaultRouter):
         try:
             serializer = viewset.serializer_class()
             resource_key = serializer.get_resource_key()
-            resource_name = serializer.get_plural_name()
+            resource_name = serializer.get_name()
+            path_name = serializer.get_plural_name()
         except:
             import traceback
             traceback.print_exc()
@@ -161,7 +162,7 @@ class DynamicRouter(DefaultRouter):
         if namespace:
             namespace = namespace.rstrip('/') + '/'
         base_path = namespace or ''
-        base_path = r'%s' % base_path + resource_name
+        base_path = r'%s' % base_path + path_name
         self.register(base_path, viewset)
 
         # Make sure resource isn't already registered.

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -11,6 +11,7 @@ from dynamic_rest.meta import get_model_table
 
 directory = {}
 resource_map = {}
+resource_name_map = {}
 
 
 def get_directory(request):
@@ -179,6 +180,7 @@ class DynamicRouter(DefaultRouter):
             'path': base_path,
             'viewset': viewset
         }
+        resource_name_map[resource_name] = resource_key
 
     @staticmethod
     def get_canonical_path(resource_key, pk=None):
@@ -203,7 +205,12 @@ class DynamicRouter(DefaultRouter):
             return base_path
 
     @staticmethod
-    def get_canonical_serializer(resource_key, model=None, instance=None):
+    def get_canonical_serializer(
+        resource_key,
+        model=None,
+        instance=None,
+        resource_name=None
+    ):
         """
         Return canonical serializer for a given resource name.
 
@@ -219,6 +226,8 @@ class DynamicRouter(DefaultRouter):
             resource_key = get_model_table(model)
         elif instance:
             resource_key = instance._meta.db_table
+        elif resource_name:
+            resource_key = resource_name_map[resource_name]
 
         if resource_key not in resource_map:
             return None

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -177,7 +177,7 @@ class UserSerializer(DynamicModelSerializer):
         'ProfileSerializer',
         deferred=True
     )
-    favorite_pet = DynamicGenericRelationField()
+    favorite_pet = DynamicGenericRelationField(required=False)
 
     def get_number_of_cats(self, user):
         return len(user.location.cat_set.all())

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -126,3 +126,29 @@ class TestGenericRelationFieldAPI(APITestCase):
         )
         response = self.client.get(url)
         self.assertEqual(400, response.status_code)
+
+    def test_patch_resource(self):
+        """
+        Test that patching a content-type field updates the underlying
+        relationship
+        """
+        user = self.fixture.users[0]
+
+        url = '/users/%s/?include[]=favorite_pet.' % user.pk
+        response = self.client.patch(
+            url,
+            json.dumps({
+                'id': user.id,
+                'favorite_pet': {
+                    'type': 'dogs',
+                    'id': 1
+                }
+            }),
+            content_type='application/json'
+        )
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertTrue('user' in content)
+        self.assertFalse('cats' in content)
+        self.assertTrue('dogs' in content)
+        self.assertEqual(1, content['dogs'][0]['id'])

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -140,7 +140,7 @@ class TestGenericRelationFieldAPI(APITestCase):
             json.dumps({
                 'id': user.id,
                 'favorite_pet': {
-                    'type': 'dogs',
+                    'type': 'dog',
                     'id': 1
                 }
             }),


### PR DESCRIPTION
Follows up on #94, adding the ability to put/patch against a polymorphic field.

I'll be following up with some additional testing, as I'm only currently testing the `PATCH` case.

Depends on #94 

Note that this also changes the assumption around the `_type` properties... Now, they're the singular version of the name, not the plural.