### PR TITLE
Make the prefix for additional primary resources configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ DYNAMIC_REST = {
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.
-    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '_'
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,11 @@ DYNAMIC_REST = {
 
     # PAGE_SIZE_QUERY_PARAM: global setting for the page size query parameter.
     # Can be overriden at the viewset level.
-    'PAGE_SIZE_QUERY_PARAM': 'per_page'
+    'PAGE_SIZE_QUERY_PARAM': 'per_page',
+
+    # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
+    # instances of the primary resource when sideloading.
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '_'
 }
 ```
 

--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -35,7 +35,11 @@ DYNAMIC_REST = {
 
     # PAGE_SIZE_QUERY_PARAM: global setting for the page size query parameter.
     # Can be overriden at the viewset level.
-    'PAGE_SIZE_QUERY_PARAM': 'per_page'
+    'PAGE_SIZE_QUERY_PARAM': 'per_page',
+
+    # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
+    # instances of the primary resource when sideloading.
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '_'
 }
 
 

--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -39,7 +39,7 @@ DYNAMIC_REST = {
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.
-    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '_'
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+'
 }
 
 

--- a/dynamic_rest/processors.py
+++ b/dynamic_rest/processors.py
@@ -5,10 +5,8 @@ from django.utils import six
 from rest_framework.serializers import ListSerializer
 from rest_framework.utils.serializer_helpers import ReturnDict
 
+from dynamic_rest.conf import settings
 from dynamic_rest.tagged import TaggedDict
-
-
-ADDITIONAL_PRIMARY_RESOURCE_PREFIX = '_'
 
 
 class SideloadingProcessor(object):
@@ -18,6 +16,8 @@ class SideloadingProcessor(object):
     response keys and produces responses that are
     typically smaller than their nested equivalent.
     """
+
+    prefix = settings.ADDITIONAL_PRIMARY_RESOURCE_PREFIX
 
     def __init__(self, serializer, data):
         """Initializes and runs the processor.
@@ -104,7 +104,7 @@ class SideloadingProcessor(object):
                 # if the primary resource is embedded, add it to a prefixed key
                 if name == self.plural_name:
                     name = '%s%s' % (
-                        ADDITIONAL_PRIMARY_RESOURCE_PREFIX,
+                        self.prefix,
                         name
                     )
 

--- a/dynamic_rest/processors.py
+++ b/dynamic_rest/processors.py
@@ -8,6 +8,9 @@ from rest_framework.utils.serializer_helpers import ReturnDict
 from dynamic_rest.tagged import TaggedDict
 
 
+ADDITIONAL_PRIMARY_RESOURCE_PREFIX = '_'
+
+
 class SideloadingProcessor(object):
     """A processor that sideloads serializer data.
 
@@ -100,7 +103,10 @@ class SideloadingProcessor(object):
 
                 # if the primary resource is embedded, add it to a prefixed key
                 if name == self.plural_name:
-                    name = '+%s' % name
+                    name = '%s%s' % (
+                        ADDITIONAL_PRIMARY_RESOURCE_PREFIX,
+                        name
+                    )
 
                 if not seen:
                     # allocate a top-level key in the data for this resource

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1374,6 +1374,6 @@ class TestCatsAPI(APITestCase):
         )
         content = json.loads(response.content.decode('utf-8'))
         self.assertTrue('cat' in content)
-        self.assertTrue('_cats' in content)
+        self.assertTrue('+cats' in content)
         self.assertEquals(content['cat']['name'], 'Kitten')
-        self.assertEquals(content['_cats'][0]['name'], 'Parent')
+        self.assertEquals(content['+cats'][0]['name'], 'Parent')


### PR DESCRIPTION
Makes the configurable. Using `_` instead of `+` matches what Ember expects for "additional sideloaded primary resources", and should allow it to use its magic. However, for backwards compatibility, the default will remain `+`