### PR TITLE
fix for making DynamicRelationField read-only by including in Meta.re…

### DIFF
--- a/dynamic_rest/fields.py
+++ b/dynamic_rest/fields.py
@@ -122,6 +122,7 @@ class DynamicRelationField(DynamicField):
             # related_name
             model_field = None
 
+        # Infer `required` and `allow_null`
         if 'required' not in self.kwargs and (
                 remote or (
                     model_field and (
@@ -134,6 +135,15 @@ class DynamicRelationField(DynamicField):
                 model_field, 'null', False
         ):
             self.allow_null = True
+
+        # Infer read_only from parent Meta.read_only_fields
+        if 'read_only' not in self.kwargs:
+            parent_ro_fields = getattr(
+                self.parent.Meta,
+                'read_only_fields',
+                []
+            )
+            self.read_only = self.field_name in parent_ro_fields
 
         self.model_field = model_field
 

--- a/dynamic_rest/fields.py
+++ b/dynamic_rest/fields.py
@@ -39,6 +39,7 @@ class DynamicField(fields.Field):
         self.requires = requires
         self.deferred = deferred
         self.field_type = field_type
+        self.kwargs = kwargs
         super(DynamicField, self).__init__(**kwargs)
 
     def to_representation(self, value):
@@ -46,6 +47,18 @@ class DynamicField(fields.Field):
 
     def to_internal_value(self, data):
         return data
+
+    def bind(self, *args, **kwargs):
+        super(DynamicField, self).bind(*args, **kwargs)
+
+        # Infer read_only from parent Meta.read_only_fields
+        if 'read_only' not in self.kwargs:
+            parent_ro_fields = getattr(
+                self.parent.Meta,
+                'read_only_fields',
+                []
+            )
+            self.read_only = self.field_name in parent_ro_fields
 
 
 class DynamicComputedField(DynamicField):
@@ -90,12 +103,11 @@ class DynamicRelationField(DynamicField):
             embed: If True, always embed related object(s). Will not sideload,
                 and will include the full object unless specifically excluded.
         """
-        self.kwargs = kwargs
         self._serializer_class = serializer_class
         self.bound = False
         self.queryset = queryset
         self.embed = embed
-        if '.' in self.kwargs.get('source', ''):
+        if '.' in kwargs.get('source', ''):
             raise Exception('Nested relationships are not supported')
         if 'link' in kwargs:
             self.link = kwargs.pop('link')
@@ -135,15 +147,6 @@ class DynamicRelationField(DynamicField):
                 model_field, 'null', False
         ):
             self.allow_null = True
-
-        # Infer read_only from parent Meta.read_only_fields
-        if 'read_only' not in self.kwargs:
-            parent_ro_fields = getattr(
-                self.parent.Meta,
-                'read_only_fields',
-                []
-            )
-            self.read_only = self.field_name in parent_ro_fields
 
         self.model_field = model_field
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -151,6 +151,7 @@ class UserSerializer(DynamicModelSerializer):
             'profile',
             'thumbnail_url'
         )
+        read_only_fields = ('profile',)
 
     location = DynamicRelationField('LocationSerializer')
     permissions = DynamicRelationField(
@@ -168,6 +169,9 @@ class UserSerializer(DynamicModelSerializer):
         requires=['location.cat_set.*'],
         deferred=True
     )
+
+    # Don't set read_only on this field directly. Used in test for
+    # Meta.read_only_fields.
     profile = DynamicRelationField(
         'ProfileSerializer',
         deferred=True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1081,6 +1081,24 @@ class TestLinks(APITestCase):
         data = szr.to_representation(FakeNested())
         self.assertEqual(data, {'value_count': 1}, data)
 
+    def test_meta_read_only_relation_field(self):
+        """Test for making a DynamicRelationField read-only by adding
+        it to Meta.read_only_fields.
+        """
+        data = {
+            'name': 'test ro',
+            'last_name': 'last',
+            'location': 1,
+            'profile': 'bogus value',  # Read only relation field
+        }
+        response = self.client.post(
+            '/users/', json.dumps(data),
+            content_type='application/json'
+        )
+        # Note: if 'profile' isn't getting ignored, this will return
+        # a 404 since a matching Profile object isn't found.
+        self.assertEquals(201, response.status_code)
+
 
 class TestDogsAPI(APITestCase):
 


### PR DESCRIPTION
Fixes a bug where adding a DynamicRelationField to `Meta.read_only_fields` doesn't actually make it read-only. This happens because DRF doesn't automagically trickle that down for us (it only does it for direct serializer mapping) and we weren't pulling it down in DREST either.