### PR TITLE
Add serializer meta flag for deferring m2m by default or not

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -327,7 +327,12 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
             fields,
             'deferred'
         )
-        if settings.DEFER_MANY_RELATIONS:
+        defer_many_relations = (
+            settings.DEFER_MANY_RELATIONS
+            if not hasattr(self.Meta, 'defer_many_relations')
+            else self.Meta.defer_many_relations
+        )
+        if defer_many_relations:
             # Auto-defer all fields, unless the 'deferred' attribute
             # on the field is specifically set to False.
             many_fields = self._get_flagged_field_names(fields, 'many')

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -47,6 +47,7 @@ class CatSerializer(DynamicModelSerializer):
 class LocationSerializer(DynamicModelSerializer):
 
     class Meta:
+        defer_many_relations = False
         model = Location
         name = 'location'
         fields = (
@@ -72,6 +73,7 @@ class LocationSerializer(DynamicModelSerializer):
 class PermissionSerializer(DynamicModelSerializer):
 
     class Meta:
+        defer_many_relations = True
         model = Permission
         name = 'permission'
         fields = ('id', 'name', 'code', 'users', 'groups')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -931,6 +931,7 @@ class TestRelationsAPI(APITestCase):
         self.assertEqual(404, r.status_code)
 
         r = self.client.get('/users/1/permissions/')
+        self.assertFalse('groups' in r.data['permissions'][0])
         self.assertEqual(200, r.status_code)
 
         r = self.client.get('/users/1/groups/')

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -595,7 +595,6 @@ class TestUserLocationSerializer(TestCase):
         }
     )
     def test_data_with_many_deferred(self):
-        # Make sure 'embed' fields can be deferred
         class UserDeferredLocationSerializer(UserLocationSerializer):
 
             class Meta:
@@ -624,7 +623,6 @@ class TestUserLocationSerializer(TestCase):
         }
     )
     def test_data_with_many_not_deferred(self):
-        # Make sure 'embed' fields can be deferred
         class UserDeferredLocationSerializer(UserLocationSerializer):
 
             class Meta:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -589,6 +589,54 @@ class TestUserLocationSerializer(TestCase):
         self.assertTrue('location' in data)
         self.assertEqual(data['location']['name'], '0')
 
+    @override_settings(
+        DYNAMIC_REST={
+            'DEFER_MANY_RELATIONS': False,
+        }
+    )
+    def test_data_with_many_deferred(self):
+        # Make sure 'embed' fields can be deferred
+        class UserDeferredLocationSerializer(UserLocationSerializer):
+
+            class Meta:
+                defer_many_relations = True
+                model = User
+                name = 'user_deferred_location'
+            groups = DynamicRelationField('GroupSerializer', many=True)
+
+        data = UserDeferredLocationSerializer(
+            self.fixture.users[0]).data
+        self.assertFalse('groups' in data)
+
+        # Now include deferred embedded field
+        data = UserDeferredLocationSerializer(
+            self.fixture.users[0],
+            request_fields={
+                'id': True,
+                'name': True,
+                'groups': True
+            }).data
+        self.assertTrue('groups' in data)
+
+    @override_settings(
+        DYNAMIC_REST={
+            'DEFER_MANY_RELATIONS': True,
+        }
+    )
+    def test_data_with_many_not_deferred(self):
+        # Make sure 'embed' fields can be deferred
+        class UserDeferredLocationSerializer(UserLocationSerializer):
+
+            class Meta:
+                defer_many_relations = False
+                model = User
+                name = 'user_deferred_location'
+            groups = DynamicRelationField('GroupSerializer', many=True)
+
+        data = UserDeferredLocationSerializer(
+            self.fixture.users[0]).data
+        self.assertTrue('groups' in data)
+
 
 @override_settings(
     DYNAMIC_REST={


### PR DESCRIPTION
Adds a flag to the serializer's Meta that allows any serializer to override the global setting `DEFER_MANY_RELATIONS`