### PR TITLE
Allow _extract_filters to be view independent by allowing filters_map

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -203,10 +203,9 @@ class DynamicFilterBackend(BaseFilterBackend):
 
         """
 
-        filters_map = (
-            kwargs.get('filters_map') or
-            self.view.get_request_feature(self.view.FILTER)
-        )
+        filters_map = kwargs.get('filters_map')
+        if filters_map is None:
+            filters_map = self.view.get_request_feature(self.view.FILTER)
 
         out = TreeMap()
 


### PR DESCRIPTION
argument to be an empty dict, too (previously checked if filters_map was
falsey, and would check for a view if so).
