### PR TITLE
Make resource vs host-relative links urls configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,12 @@ DYNAMIC_REST = {
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.
-    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+'
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+',
+
+    # Enables host-relative links.  Only compatible with resources registered
+    # through the dynamic router.  If a resource doesn't have a canonical
+    # path registered, links will default back to being resource-relative urls
+    'ENABLE_HOST_RELATIVE_LINKS': True
 }
 ```
 

--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -46,7 +46,12 @@ DYNAMIC_REST = {
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.
-    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+'
+    'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+',
+
+    # Enables host-relative links.  Only compatible with resources registered
+    # through the dynamic router.  If a resource doesn't have a canonical
+    # path registered, links will default back to being resource-relative urls
+    'ENABLE_HOST_RELATIVE_LINKS': True,
 }
 
 

--- a/dynamic_rest/links.py
+++ b/dynamic_rest/links.py
@@ -1,5 +1,7 @@
 """This module contains utilities to support API links."""
 from django.utils import six
+from dynamic_rest.conf import settings
+from .routers import DynamicRouter
 
 
 def merge_link_object(serializer, data, instance):
@@ -23,13 +25,19 @@ def merge_link_object(serializer, data, instance):
         if name in data and not data[name]:
             continue
 
+        link = getattr(field, 'link', None)
+        if link is None:
+            base_url = ''
+            if settings.ENABLE_HOST_RELATIVE_LINKS:
+                # if the resource isn't registered, this will default back to
+                # using resource-relative urls for links.
+                base_url = DynamicRouter.get_canonical_path(
+                    serializer.get_resource_key(),
+                    instance.pk
+                ) or ''
+            link = '%s%s/' % (base_url, name)
         # Default to DREST-generated relation endpoints.
-        link = getattr(field, 'link', "/%s/%s/%s/" % (
-            serializer.get_plural_name(),
-            instance.pk,
-            name
-        ))
-        if callable(link):
+        elif callable(link):
             link = link(name, field, data, instance)
 
         link_object[name] = link

--- a/dynamic_rest/links.py
+++ b/dynamic_rest/links.py
@@ -1,7 +1,8 @@
 """This module contains utilities to support API links."""
 from django.utils import six
+
 from dynamic_rest.conf import settings
-from .routers import DynamicRouter
+from dynamic_rest.routers import DynamicRouter
 
 
 def merge_link_object(serializer, data, instance):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1021,7 +1021,7 @@ class TestLinks(APITestCase):
 
         # test for default link (auto-generated relation endpoint)
         # Note that the pluralized name is used rather than the full prefix.
-        self.assertEqual(cat['links']['foobar'], '/cats/1/foobar/')
+        self.assertEqual(cat['links']['foobar'], '/v2/cats/1/foobar/')
 
         # test for dynamically generated link URL
         cat1 = Cat.objects.get(pk=1)
@@ -1029,6 +1029,23 @@ class TestLinks(APITestCase):
             cat['links']['backup_home'],
             '/locations/%s/?include[]=address' % cat1.backup_home.pk
         )
+
+    @override_settings(
+        DYNAMIC_REST={
+            'ENABLE_HOST_RELATIVE_LINKS': False
+        }
+    )
+    def test_relative_links(self):
+        r = self.client.get('/v2/cats/1/')
+        self.assertEqual(200, r.status_code)
+        content = json.loads(r.content.decode('utf-8'))
+
+        cat = content['cat']
+        self.assertTrue('links' in cat)
+
+        # test that links urls become resource-relative urls when
+        # host-relative urls are turned off.
+        self.assertEqual(cat['links']['foobar'], 'foobar/')
 
     def test_including_empty_relation_hides_link(self):
         r = self.client.get('/v2/cats/1/?include[]=foobar')


### PR DESCRIPTION
Not a whole lot to this one.  Adds a setting to allow us to set the default `link` format to be host-relative URLs.

Note that in order for these links to be effectively generated, the primary resource must be registered with DynamicRouter.  If the resource isn't registered with DynamicRouter, all `links` generated will default back to resource-relative URLs.

This does change the base behavior of links; instead of namespace-relative urls (that were technically invalid URLs), the default behavior is now a proper URL (host-relative or resource-relative), in both cases.