### PR TITLE
link field performance optimization

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -424,12 +424,12 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
                     not (
                         # Skip sideloaded fields
                         name in self.fields and
-                        not field.serializer.id_only()
+                        isinstance(self.request_fields.get(name), dict)
                     ) and not (
                         # Skip included single relations
                         # TODO: Use links, when we can generate canonical URLs
                         name in self.fields and
-                        not getattr(field.serializer, 'many', False)
+                        not getattr(field, 'many', False)
                     )
                 }
 

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -409,6 +409,11 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
 
         return serializer_fields
 
+    def is_field_sideloaded(self, field_name):
+        if not isinstance(self.request_fields, dict):
+            return False
+        return isinstance(self.request_fields.get(field_name), dict)
+
     def get_link_fields(self):
         """Construct dict of name:field for linkable fields."""
         if not hasattr(self, '_link_fields'):
@@ -424,7 +429,7 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
                     not (
                         # Skip sideloaded fields
                         name in self.fields and
-                        isinstance(self.request_fields.get(name), dict)
+                        self.is_field_sideloaded(name)
                     ) and not (
                         # Skip included single relations
                         # TODO: Use links, when we can generate canonical URLs


### PR DESCRIPTION
The `get_link_fields` method was calling `field.serializer`, causing serializers to be constructed, which turns out to be very expensive. This PR uses alternative means of accomplishing the same logic that don't require serializers to be constructed. (In one API hitting 4 resources, this resulted in a ~25% reduction in CPU usage.)

Before (blue boxes show serializer construction caused by `get_link_fields`):
<img width="972" alt="screen shot 2016-05-25 at 3 09 55 pm" src="https://cloud.githubusercontent.com/assets/172724/15558996/80f330b8-2293-11e6-896d-8620dc3fa174.png">

After:
<img width="967" alt="screen shot 2016-05-25 at 4 08 42 pm" src="https://cloud.githubusercontent.com/assets/172724/15559005/919df362-2293-11e6-8dce-c0285fa07fd6.png">
