### PR TITLE
fix bug in GenericFKField

### DIFF
--- a/dynamic_rest/fields/generic.py
+++ b/dynamic_rest/fields/generic.py
@@ -55,8 +55,7 @@ class DynamicGenericRelationField(
         # but for generic relations, we want IDs to be represented differently
         # and that is a field-level concern, not an object-level concern,
         # so we handle it here.
-        request_fields = self.request_fields
-        return request_fields is True
+        return not self.parent.is_field_sideloaded(self.field_name)
 
     def get_pk_object(self, type_key, id_value):
         return {


### PR DESCRIPTION
There was a bug in GenericForeignKeyField's `id_only()` method where it was erroneously returning `False` if the field was being included by default (and therefore didn't have a key in `request_fields`). This PR fixes the bug by using the new `.is_field_sideloaded()` method (i.e. `id_only` is true if the field isn't being sideloaded). 