### PR TITLE
protect against weird and broken query params, e.g. "?" where they sh…

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -527,6 +527,10 @@ class DynamicFilterBackend(BaseFilterBackend):
                 raise ValidationError(
                     dict(e) if hasattr(e, 'error_dict') else list(e)
                 )
+            except Exception as e:
+                # Some other Django error in parsing the filter. Very likely
+                # a bad query, so throw a ValidationError.
+                raise ValidationError(e.message)
 
         # A serializer can have this optional function
         # to dynamically apply additional filters on

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -530,7 +530,8 @@ class DynamicFilterBackend(BaseFilterBackend):
             except Exception as e:
                 # Some other Django error in parsing the filter. Very likely
                 # a bad query, so throw a ValidationError.
-                raise ValidationError(e.message)
+                err_msg = getattr(e, 'message', '')
+                raise ValidationError(err_msg)
 
         # A serializer can have this optional function
         # to dynamically apply additional filters on

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1491,3 +1491,15 @@ class TestCatsAPI(APITestCase):
         # ... and it should not have changed:
         self.assertEqual(data['cat']['parent'], parent_id)
         self.assertEqual(data['cat']['name'], kitten_name)
+
+
+class TestFilters(APITestCase):
+
+    """
+    Tests for filters.
+    """
+
+    def testUnparseableInt(self):
+        url = '/users/?filter{pk}=123x'
+        response = self.client.get(url)
+        self.assertEqual(400, response.status_code)


### PR DESCRIPTION
…ouldnt be.

This corrects the response to queries like `http://localhost:9001/v3/posts?filter{creator}=17401?&format=json`, which now returns a 400 with `[
"invalid literal for int() with base 10: '17401?'"
]` instead of a 500.