### PR TITLE
Support Meta.preserve_whitespace fields list

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -393,6 +393,14 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
         ro_fields = getattr(self.Meta, 'read_only_fields', [])
         self.flag_fields(serializer_fields, ro_fields, 'read_only', True)
 
+        pw_fields = getattr(self.Meta, 'preserve_whitespace', [])
+        self.flag_fields(
+            serializer_fields,
+            pw_fields,
+            'trim_whitespace',
+            False,
+        )
+
         # Toggle read_only flags for immutable fields.
         # Note: This overrides `read_only` if both are set, to allow
         #       inferred DRF fields to be made immutable.
@@ -549,7 +557,7 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
         return instance
 
     def id_only(self):
-        """Check whether the serializer should return an ID instead of an object.
+        """Whether the serializer should return an ID instead of an object.
 
         Returns:
             True if and only if `request_fields` is True.

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -121,6 +121,17 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
     """Base class for DREST serializers.
 
     This class provides support for dynamic field inclusions/exclusions.
+
+    Like DRF, DREST serializers support a few Meta class options:
+        - model - class
+        - name - string
+        - plural_name - string
+        - defer_many_relations - bool
+        - fields - list of strings
+        - deferred_fields - list of strings
+        - immutable_fields - list of strings
+        - read_only_fields - list of strings
+        - untrimmed_fields - list of strings
     """
     def __new__(cls, *args, **kwargs):
         """
@@ -393,7 +404,7 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
         ro_fields = getattr(self.Meta, 'read_only_fields', [])
         self.flag_fields(serializer_fields, ro_fields, 'read_only', True)
 
-        pw_fields = getattr(self.Meta, 'preserve_whitespace', [])
+        pw_fields = getattr(self.Meta, 'untrimmed_fields', [])
         self.flag_fields(
             serializer_fields,
             pw_fields,

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -42,7 +42,7 @@ class CatSerializer(DynamicModelSerializer):
         fields = ('id', 'name', 'home', 'backup_home', 'foobar', 'parent')
         deferred_fields = ('home', 'backup_home', 'foobar', 'parent')
         immutable_fields = ('name',)
-        preserve_whitespace = ('name',)
+        untrimmed_fields = ('name',)
 
 
 class LocationSerializer(DynamicModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -42,6 +42,7 @@ class CatSerializer(DynamicModelSerializer):
         fields = ('id', 'name', 'home', 'backup_home', 'foobar', 'parent')
         deferred_fields = ('home', 'backup_home', 'foobar', 'parent')
         immutable_fields = ('name',)
+        preserve_whitespace = ('name',)
 
 
 class LocationSerializer(DynamicModelSerializer):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1455,6 +1455,22 @@ class TestCatsAPI(APITestCase):
         self.assertEquals(content['cat']['name'], 'Kitten')
         self.assertEquals(content['+cats'][0]['name'], 'Parent')
 
+    def test_allows_whitespace(self):
+        data = {
+            'name': '  Zahaklu  ',
+            'home': self.kitten.home_id,
+            'backup_home': self.kitten.backup_home_id,
+            'parent': self.kitten.parent_id,
+        }
+        response = self.client.post(
+            '/cats/',
+            json.dumps(data),
+            content_type='application/json',
+        )
+        self.assertEqual(201, response.status_code)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data['cat']['name'], '  Zahaklu  ')
+
     def test_immutable_field(self):
         """ Make sure immutable 'parent' field can be set on POST """
         parent_id = self.kitten.parent_id


### PR DESCRIPTION
DRF automatically trims whitespace on CharFields.  This can be turned off by setting the flag to False on that field.   This PR adds a Meta parameter for overriding this flag.