### PR TITLE
Remove isort testing

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-multi_line_output=3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When making contributions, try to follow these guidelines:
 
 Use `make lint` to check your code for style violations.
 
-We use the `flake8` and `isort` linters to enforce PEP8 code style. 
+We use the `flake8` linter to enforce PEP8 code style. 
 For additional details, see our [Python style guide](https://github.com/AltSchool/Python).
 
 ## Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Sphinx==1.3.4
 dj-database-url==0.3.0
 django-debug-toolbar==1.4
 flake8==2.4.0
-isort==4.2.2
 pytest-cov==1.8.1
 pytest-django==2.8.0
 pytest-sugar==0.5.1

--- a/runtests.py
+++ b/runtests.py
@@ -23,8 +23,6 @@ PYTEST_ARGS = {
 
 FLAKE8_ARGS = [APP_NAME, TESTS]
 
-ISORT_ARGS = ['--recursive', '--check-only', APP_NAME, TESTS]
-
 sys.path.append(os.path.dirname(__file__))
 
 
@@ -37,21 +35,6 @@ def flake8_main(args):
     print('Running flake8 code linting')
     ret = subprocess.call(['flake8'] + args)
     print('flake8 failed' if ret else 'flake8 passed')
-    return ret
-
-
-def isort_main(args):
-    print('Running isort code checking')
-    ret = subprocess.call(['isort'] + args)
-
-    if ret:
-        print(
-            'isort failed: Some modules have incorrectly ordered imports. '
-            'Fix by running `isort --recursive .`'
-        )
-    else:
-        print('isort passed')
-
     return ret
 
 
@@ -75,10 +58,8 @@ if __name__ == "__main__":
         sys.argv.remove('--nolint')
     except ValueError:
         run_flake8 = True
-        run_isort = True
     else:
         run_flake8 = False
-        run_isort = False
 
     try:
         sys.argv.remove('--lintonly')
@@ -101,7 +82,6 @@ if __name__ == "__main__":
     else:
         style = 'fast'
         run_flake8 = False
-        run_isort = False
 
     if len(sys.argv) > 1:
         pytest_args = sys.argv[1:]
@@ -142,6 +122,3 @@ if __name__ == "__main__":
 
     if run_flake8:
         exit_on_failure(flake8_main(FLAKE8_ARGS))
-
-    if run_isort:
-        exit_on_failure(isort_main(ISORT_ARGS))


### PR DESCRIPTION
`isort` tests that module imports are sorted in alphabetical order within system, 3rd party, and 1st party blocks.

Unfortunately, it seems to be somewhat flaky in its detection of 3rd party vs 1st party packages, to the extent that it produces inconsistent results between local testing and CircleCI testing, and even between different runs of the same code on CircleCI (??).

As such, we have decided to remove it and rely exclusively on flake8 for linting.