### PR TITLE
Support Django >= 1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ db.sqlite3
 
 # pypi
 .pypirc
+
+# PyCharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ but it can be used to provide fast and flexible CRUD operations to any consumer 
 # Requirements
 
 * Python (2.7, 3.3, 3.4, 3.5)
-* Django (1.7, 1.8, 1.9)
-* Django REST Framework (3.1, 3.2, 3.3)
+* Django (1.7, 1.8, 1.9, 1.10)
+* Django REST Framework (3.1, 3.2, 3.3, 3.4)
 
 # Installation
 
@@ -619,6 +619,9 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 2.7    | 1.9    | 3.2 | YES |
 | 2.7    | 1.9    | 3.3 | YES |
 | 2.7    | 1.9    | 3.4 | YES |
+| 2.7    | 1.10   | 3.2 | YES |
+| 2.7    | 1.10   | 3.3 | YES |
+| 2.7    | 1.10   | 3.4 | YES |
 | 3.3    | 1.7    | 3.1 | YES |
 | 3.3    | 1.7    | 3.2 | YES |
 | 3.3    | 1.7    | 3.3 | YES |
@@ -643,6 +646,9 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 3.4    | 1.9    | 3.2 | YES |
 | 3.4    | 1.9    | 3.3 | YES |
 | 3.4    | 1.9    | 3.4 | YES |
+| 3.4    | 1.10   | 3.2 | YES |
+| 3.4    | 1.10   | 3.3 | YES |
+| 3.4    | 1.10   | 3.4 | YES |
 | 3.5    | 1.7    | 3.1 | NO<sup>3</sup> |
 | 3.5    | 1.7    | 3.2 | NO<sup>3</sup> |
 | 3.5    | 1.7    | 3.3 | NO<sup>3</sup> |
@@ -655,6 +661,9 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 3.5    | 1.9    | 3.2 | YES |
 | 3.5    | 1.9    | 3.3 | YES |
 | 3.5    | 1.9    | 3.4 | YES |
+| 3.5    | 1.10   | 3.2 | YES |
+| 3.5    | 1.10   | 3.3 | YES |
+| 3.5    | 1.10   | 3.4 | YES |
 
 * 1: Django 1.9 is not compatible with DRF 3.1
 * 2: Django 1.9 is not compatible with Python 3.3

--- a/dynamic_rest/meta.py
+++ b/dynamic_rest/meta.py
@@ -49,7 +49,7 @@ def get_model_field(model, field_name):
             related_objs = (
                 f for f in meta.get_fields()
                 if (f.one_to_many or f.one_to_one)
-                   and f.auto_created and not f.concrete
+                and f.auto_created and not f.concrete
             )
             related_m2m_objs = (
                 f for f in meta.get_fields(include_hidden=True)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
        {py27,py33,py34}-django17-drf{31,32,33},
        {py27,py33,py34,py35}-django18-drf{31,32,33},
        {py27,py34,py35}-django19-drf{32,33},
+       {py27,py34,py35}-django110-drf{32,33,34},
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
@@ -16,9 +17,11 @@ deps =
         django17: Django==1.7.11
         django18: Django==1.8.7
         django19: Django==1.9.1
+        django110: Django==1.10.0
         drf31: djangorestframework==3.1.0
         drf32: djangorestframework==3.2.0
         drf33: djangorestframework==3.3.0
+        drf34: djangorestframework==3.4.0
         -rrequirements.txt
 
 [testenv:py27-lint]


### PR DESCRIPTION
Fix get_field_by_name, get_all_related_objects, get_all_related_many_to_many_objects for Django >= 1.10