### PR TITLE
Exclude delete requests from having fields deferred

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -504,7 +504,11 @@ class DynamicFilterBackend(BaseFilterBackend):
         # use requirements at this level to limit fields selected
         # only do this for GET requests where we are not requesting the
         # entire fieldset
-        if '*' not in requirements and not self.view.is_update():
+        if (
+            '*' not in requirements and
+            not self.view.is_update() and
+            not self.view.is_delete()
+        ):
             id_fields = getattr(serializer, 'get_id_fields', lambda: [])()
             # only include local model fields
             only = [

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -15,6 +15,7 @@ from dynamic_rest.processors import SideloadingProcessor
 from dynamic_rest.renderers import DynamicBrowsableAPIRenderer
 
 UPDATE_REQUEST_METHODS = ('PUT', 'PATCH', 'POST')
+DELETE_REQUEST_METHOD = 'DELETE'
 
 
 class QueryParams(QueryDict):
@@ -235,6 +236,15 @@ class WithDynamicViewSetMixin(object):
         if (
             self.request and
             self.request.method.upper() in UPDATE_REQUEST_METHODS
+        ):
+            return True
+        else:
+            return False
+
+    def is_delete(self):
+        if (
+            self.request and
+            self.request.method.upper() == DELETE_REQUEST_METHOD
         ):
             return True
         else:


### PR DESCRIPTION
When using `.only` on querysets, the objects returned aren't actually instances of the model, but derived instances of the class that signify that certain fields are deferred.  This causes certain signals to not be fired, since we typically wire these up by way of `post_save` or `post_delete` hooks, connected with a particular model class as a sender.

Since django apparently strictly matches the model being acted on to the sender passed in through the `@receiver` decorator or `.connect` (i.e. `@receiver(post_delete, sender=FooModel)`), this causes models with deferred fields to not invoke the proper signal handlers.

See this [stack overflow answer](See http://stackoverflow.com/questions/35006328/post-delete-pre-delete-signals-not-firing-for-specific-sender) for more details.

This fix prevents the use of `.only` on `DELETE` requests in addition to `PUT/PATCH/POST` requests, which in turn prevents deferred subclasses from being used.