### PR TITLE
Only return 405 on AssertionError (unable to retrieve pk)

### DIFF
--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -519,12 +519,9 @@ class DynamicModelViewSet(WithDynamicViewSetMixin, viewsets.ModelViewSet):
         bulk_payload = self._get_bulk_payload(request)
         if bulk_payload:
             return self._destroy_many(bulk_payload)
-        try:
-            # check if the request is formatted in such a way that
-            # we can get the object
-            self.get_object()
-        except:
-            # if not, assume that it is a poorly formatted bulk request
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        if lookup_url_kwarg not in kwargs:
+            # assume that it is a poorly formatted bulk request
             return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
         return super(DynamicModelViewSet, self).destroy(
             request, *args, **kwargs)

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -371,3 +371,12 @@ class BulkDeletionTestCase(TestCase):
             response.status_code,
             status.HTTP_405_METHOD_NOT_ALLOWED
         )
+
+    def test_delete_on_nonexistent_raises_404(self):
+        response = self.client.delete(
+            '/dogs/31415'
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_404_NOT_FOUND
+        )


### PR DESCRIPTION
We don't want to return 405's in all situations, only when we weren't able to retrieve the primary key. `get_object` could fail even if we have the primary key, for example if `filter_queryset` excludes the object.