### PR TITLE
attempt to fix 1.10 prefetch a__b nested issue

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -322,16 +322,10 @@ class DynamicFilterBackend(BaseFilterBackend):
             related_field = get_model_field(model, source)
             related_model = get_related_model(related_field)
 
-            if related_model is None:
-                # GenericForeignKey has no related_model
-                # in this case, prefetch the generic relationship itself
-                prefetches[source] = source
-                continue
-
             queryset = self._build_internal_queryset(
                 related_model,
                 remainder
-            )
+            ) if related_model else None
 
             prefetches[source] = Prefetch(
                 source,

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -365,7 +365,15 @@ class DynamicFilterBackend(BaseFilterBackend):
                 # GenericForeignKey has no related_model
                 # in this case, prefetch the generic relationship itself
                 prefetches[source] = source
+                if self.DEBUG:
+                    self._prefetches[source] = source
                 continue
+
+            if self.DEBUG:
+                # push prefetches
+                pfs = self._prefetches
+                self._prefetches[source] = {}
+                self._prefetches = self._prefetches[source]
 
             queryset = self._filter_queryset(
                 serializer=None,
@@ -374,6 +382,11 @@ class DynamicFilterBackend(BaseFilterBackend):
                 queryset=None,
                 requirements=remainder
             )
+
+            if self.DEBUG:
+                # pop back
+                self._prefetches = pfs
+
             prefetches[source] = Prefetch(
                 source,
                 queryset=queryset

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -350,7 +350,7 @@ class DynamicFilterBackend(BaseFilterBackend):
         prefetch = prefetches.values()
         queryset = queryset.prefetch_related(*prefetch).distinct()
         if self.DEBUG:
-            queryset._prefetches = prefetches.keys()
+            queryset._using_prefetches = prefetches
         return queryset
 
     def _add_request_prefetches(
@@ -581,7 +581,7 @@ class DynamicFilterBackend(BaseFilterBackend):
             queryset = queryset.distinct()
 
         if self.DEBUG:
-            queryset._prefetches = prefetches.keys()
+            queryset._using_prefetches = prefetches
         return queryset
 
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -74,7 +74,7 @@ class TestUserViewSet(TestCase):
         }
 
         backend = DynamicFilterBackend()
-        out = backend._extract_filters(filters_map=filters_map)
+        out = backend._get_requested_filters(filters_map=filters_map)
         self.assertEqual(out['_include']['attr'].value, 'bar')
         self.assertEqual(out['_include']['attr2'].value, 'bar')
         self.assertEqual(out['_exclude']['attr3'].value, 'bar')
@@ -102,7 +102,7 @@ class TestUserViewSet(TestCase):
         }
 
         backend = DynamicFilterBackend()
-        out = backend._extract_filters(filters_map=filters_map)
+        out = backend._get_requested_filters(filters_map=filters_map)
 
         self.assertEqual(out['_include']['f1__isnull'].value, True)
         self.assertEqual(out['_include']['f2__isnull'].value, ['a'])


### PR DESCRIPTION
During our Django upgrade work, we noticed that nested prefetches which worked in Django 1.9/1.8/1.7 are now misbehaving in Django 1.10.

This only applies to nested prefetch objects that use a queryset which itself prefetches a distant relationship using the original `a__b` prefetch syntax.

For example, the following query fails in Django 1.10 but works in earlier versions:

```
A.objects.all().prefetch_related(
    Prefetch(
        'b',
        queryset=B.objects.all().prefetch_related(
            'c__d'
        )
    )
)
# raises AttributeError: Cannot find 'd' on RelatedManager object, 'b__c__d' is an invalid parameter to prefetch_related()
```

However, if we change the internal prefetch of `c__d` to use the fully-nested syntax, all is well in Django 1.10:

```
A.objects.all().prefetch_related(
    Prefetch(
        'b',
        queryset=B.objects.all().prefetch_related(
            Prefetch(
                'c',
                queryset=C.objects.all().prefetch_related(
                    'd'
                )
            )
        )
    )
)
# No problem
```

TODOs:
- [x] Report this to Django: https://code.djangoproject.com/ticket/27554