### PR TITLE
Loosen version requirements to match real world usage

### DIFF
--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -93,8 +93,9 @@ class WithDynamicViewSetMixin(object):
             # WSGIRequest does not support Unicode values in the query string.
             # Deal with this here to avoid 500s, code adapted from:
             # https://github.com/django/django/blob/1.7.9/django/core/handlers/wsgi.py#L130 # noqa
-            d = request.environ.get('QUERY_STRING', '').decode('utf-8')
-            request.GET = QueryParams(d.encode('utf-8'))
+            request.GET = QueryParams(
+                request.environ.get('QUERY_STRING', '').encode('utf-8')
+            )
 
         request = super(WithDynamicViewSetMixin, self).initialize_request(
             request, *args, **kargs

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -93,9 +93,8 @@ class WithDynamicViewSetMixin(object):
             # WSGIRequest does not support Unicode values in the query string.
             # Deal with this here to avoid 500s, code adapted from:
             # https://github.com/django/django/blob/1.7.9/django/core/handlers/wsgi.py#L130 # noqa
-            request.GET = QueryParams(
-                request.environ.get('QUERY_STRING', '').encode('utf-8')
-            )
+            d = request.environ.get('QUERY_STRING', '').decode('utf-8')
+            request.GET = QueryParams(d.encode('utf-8'))
 
         request = super(WithDynamicViewSetMixin, self).initialize_request(
             request, *args, **kargs

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
-Django>=1.7,<=1.10
-djangorestframework>=3.1.0,<=3.4.0
+Django>=1.7,<1.11
+djangorestframework>=3.1.0,<=3.6.0
 inflection==0.3.1
 requests

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
 Django>=1.7,<1.11
-djangorestframework>=3.1.0,<=3.6.0
+djangorestframework>=3.1.0,<3.6.0
 inflection==0.3.1
 requests

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -199,6 +199,7 @@ class ProfileSerializer(DynamicModelSerializer):
     class Meta:
         model = Profile
         name = 'profile'
+        fields = '__all__'
 
     user = DynamicRelationField('UserSerializer')
     user_location_name = DynamicField(
@@ -257,6 +258,7 @@ class HorseSerializer(DynamicModelSerializer):
     class Meta:
         model = Horse
         name = 'horse'
+        fields = '__all__'
 
 
 class ZebraSerializer(DynamicModelSerializer):
@@ -264,3 +266,4 @@ class ZebraSerializer(DynamicModelSerializer):
     class Meta:
         model = Zebra
         name = 'zebra'
+        fields = '__all__'

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -199,7 +199,6 @@ class ProfileSerializer(DynamicModelSerializer):
     class Meta:
         model = Profile
         name = 'profile'
-        fields = '__all__'
 
     user = DynamicRelationField('UserSerializer')
     user_location_name = DynamicField(
@@ -258,7 +257,6 @@ class HorseSerializer(DynamicModelSerializer):
     class Meta:
         model = Horse
         name = 'horse'
-        fields = '__all__'
 
 
 class ZebraSerializer(DynamicModelSerializer):
@@ -266,4 +264,3 @@ class ZebraSerializer(DynamicModelSerializer):
     class Meta:
         model = Zebra
         name = 'zebra'
-        fields = '__all__'

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -199,6 +199,12 @@ class ProfileSerializer(DynamicModelSerializer):
     class Meta:
         model = Profile
         name = 'profile'
+        fields = (
+            'user',
+            'display_name',
+            'thumbnail_url',
+            'user_location_name',
+        )
 
     user = DynamicRelationField('UserSerializer')
     user_location_name = DynamicField(
@@ -257,6 +263,11 @@ class HorseSerializer(DynamicModelSerializer):
     class Meta:
         model = Horse
         name = 'horse'
+        fields = (
+            'id',
+            'name',
+            'origin',
+        )
 
 
 class ZebraSerializer(DynamicModelSerializer):
@@ -264,3 +275,8 @@ class ZebraSerializer(DynamicModelSerializer):
     class Meta:
         model = Zebra
         name = 'zebra'
+        fields = (
+            'id',
+            'name',
+            'origin',
+        )

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -600,6 +600,7 @@ class TestUserLocationSerializer(TestCase):
             class Meta:
                 model = User
                 name = 'user_deferred_location'
+                fields = '__all__'
             location = DynamicRelationField(
                 LocationSerializer, embed=True, deferred=True
             )
@@ -635,6 +636,7 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = True
                 model = User
                 name = 'user_deferred_location'
+                fields = '__all__'
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(
@@ -665,6 +667,7 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = False
                 model = User
                 name = 'user_deferred_location'
+                fields = '__all__'
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -600,7 +600,6 @@ class TestUserLocationSerializer(TestCase):
             class Meta:
                 model = User
                 name = 'user_deferred_location'
-                fields = '__all__'
             location = DynamicRelationField(
                 LocationSerializer, embed=True, deferred=True
             )
@@ -636,7 +635,6 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = True
                 model = User
                 name = 'user_deferred_location'
-                fields = '__all__'
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(
@@ -667,7 +665,6 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = False
                 model = User
                 name = 'user_deferred_location'
-                fields = '__all__'
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -600,6 +600,11 @@ class TestUserLocationSerializer(TestCase):
             class Meta:
                 model = User
                 name = 'user_deferred_location'
+                fields = (
+                    'id',
+                    'name',
+                    'location',
+                )
             location = DynamicRelationField(
                 LocationSerializer, embed=True, deferred=True
             )
@@ -635,6 +640,11 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = True
                 model = User
                 name = 'user_deferred_location'
+                fields = (
+                    'id',
+                    'name',
+                    'groups',
+                )
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(
@@ -665,6 +675,9 @@ class TestUserLocationSerializer(TestCase):
                 defer_many_relations = False
                 model = User
                 name = 'user_deferred_location'
+                fields = (
+                    'groups',
+                )
             groups = DynamicRelationField('GroupSerializer', many=True)
 
         data = UserDeferredLocationSerializer(


### PR DESCRIPTION
We currently use Django 1.10.3 and djangorestframework 3.5.2 with dynamic-rest. These versions fall outside the range allowed by dynamic-rest's install_requires.txt. We loosen the version requirements here to match real world usage.

It appears that this PR changes the tox tests. We never actually tested DRF 3.5 previously. E.g. notice ```djangorestframework==3.4.0``` in snippet of tox test logs:

```
py27-django110-drf35 create: /home/ubuntu/dynamic-rest/.tox/py27-django110-drf35
py27-django110-drf35 installdeps: Django==1.10.0, djangorestframework==3.5.0, -rrequirements.txt
py27-django110-drf35 inst: /home/ubuntu/dynamic-rest/.tox/dist/dynamic-rest-1.6.2.zip
py27-django110-drf35 installed: alabaster==0.7.9,appdirs==1.4.2,Babel==2.3.4,baron==0.6.5,click==6.7,cov-core==1.15.0,coverage==3.7.1,dj-database-url==0.3.0,Django==1.10,django-debug-toolbar==1.4,djangorestframework==3.4.0,djay==0.0.3,docutils==0.13.1,dynamic-rest==1.6.2,flake8==2.4.0,inflection==0.3.1,Jinja2==2.9.5,MarkupSafe==0.23,mccabe==0.3.1,packaging==16.8,pep8==1.5.7,pluggy==0.3.1,psycopg2==2.5.1,py==1.4.32,pyflakes==0.8.1,Pygments==2.2.0,pyparsing==2.1.10,pytest==2.7.2,pytest-cov==1.8.1,pytest-django==2.8.0,pytest-sugar==0.5.1,pytz==2016.10,PyYAML==3.12,redbaron==0.6.3,requests==2.13.0,rply==0.7.4,six==1.10.0,snowballstemmer==1.2.1,Sphinx==1.3.4,sphinx-rtd-theme==0.1.9,sqlparse==0.2.2,termcolor==1.1.0,tox==2.3.1,tox-pyenv==1.0.2,virtualenv==15.1.0
py27-django110-drf35 runtests: PYTHONHASHSEED='3897255342'
py27-django110-drf35 runtests: commands[0] | ./runtests.py --fast --coverage -rw
Test session starts (platform: linux2, Python 2.7.10, pytest 2.7.2, pytest-sugar 0.5.1)
rootdir: /home/ubuntu/dynamic-rest, inifile: pytest.ini
```

 A few small changes have been made to fix tests. The encoding handling change is targeted at Python 2.7 + Django 1.10 + DRF 3.5 where QUERY_STRING is returned already encoded.

See https://altschool.atlassian.net/browse/ALTOS-12884 for context.