### PR TITLE
Allow setting Meta.list_serializer_class

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -142,7 +142,11 @@ class WithDynamicSerializerMixin(WithResourceKeyMixin, DynamicSerializerBase):
         if not meta:
             meta = type('Meta', (), {})
             cls.Meta = meta
-        meta.list_serializer_class = DynamicListSerializer
+        list_serializer_class = getattr(
+            meta, 'list_serializer_class', DynamicListSerializer)
+        if not issubclass(list_serializer_class, DynamicListSerializer):
+            list_serializer_class = DynamicListSerializer
+        meta.list_serializer_class = list_serializer_class
         return super(
             WithDynamicSerializerMixin, cls
         ).__new__(


### PR DESCRIPTION
The way that `DynamicModelSerializer` is currently written it is not possible to define a custom `list_serializer_class`, as that attribute is overridden in the `__new__` method. Provided that the user-defined `list_serializer_class` extends `DynamicListSerializer`, it should be settable.