### PR TITLE
Ensure models aren't deleted multiple times

### DIFF
--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -524,9 +524,10 @@ class DynamicModelViewSet(WithDynamicViewSetMixin, viewsets.ModelViewSet):
             request, *args, **kwargs)
 
     def _destroy_many(self, data):
-        for instance in self.get_queryset().filter(
+        instances = self.get_queryset().filter(
             id__in=[d['id'] for d in data]
-        ):
+        ).distinct()
+        for instance in instances:
             self.check_object_permissions(self.request, instance)
             self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Given that `get_queryset` returns a configurable queryset, we may end up with an edge case where the same model is returned multiple times.

Ensure that the set is distinct before attempting to delete models, to prevent issues around trying to delete a model multiple times.