### PR TITLE
Upgrade/2017 04

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ but it can be used to provide fast and flexible CRUD operations to any consumer 
 # Requirements
 
 * Python (2.7, 3.3, 3.4, 3.5)
-* Django (1.7, 1.8, 1.9, 1.10)
-* Django REST Framework (3.1, 3.2, 3.3, 3.4, 3.5)
+* Django (1.8, 1.9, 1.10, 1.11)
+* Django REST Framework (3.1, 3.2, 3.3, 3.4, 3.5, 3.6)
 
 # Installation
 
@@ -609,10 +609,6 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 
 | Python | Django | DRF | OK  |
 | ------ | ------ | --- | --- |
-| 2.7    | 1.7    | 3.1 | YES |
-| 2.7    | 1.7    | 3.2 | YES |
-| 2.7    | 1.7    | 3.3 | YES |
-| 2.7    | 1.7    | 3.4 | NO<sup>4</sup> |
 | 2.7    | 1.8    | 3.1 | YES |
 | 2.7    | 1.8    | 3.2 | YES |
 | 2.7    | 1.8    | 3.3 | YES |
@@ -621,26 +617,21 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 2.7    | 1.9    | 3.2 | YES |
 | 2.7    | 1.9    | 3.3 | YES |
 | 2.7    | 1.9    | 3.4 | YES |
-| 2.7    | 1.10   | 3.2 | NO<sup>5</sup> |
-| 2.7    | 1.10   | 3.3 | NO<sup>5</sup> |
+| 2.7    | 1.10   | 3.2 | NO<sup>3</sup> |
+| 2.7    | 1.10   | 3.3 | NO<sup>3</sup> |
 | 2.7    | 1.10   | 3.4 | YES |
 | 2.7    | 1.10   | 3.5 | YES |
-| 3.3    | 1.7    | 3.1 | YES |
-| 3.3    | 1.7    | 3.2 | YES |
-| 3.3    | 1.7    | 3.3 | YES |
-| 3.3    | 1.7    | 3.3 | NO<sup>4</sup> |
+| 2.7    | 1.10   | 3.6 | YES |
+| 2.7    | 1.11   | 3.4 | YES |
+| 2.7    | 1.11   | 3.5 | YES |
+| 2.7    | 1.11   | 3.6 | YES |
 | 3.3    | 1.8    | 3.1 | YES |
 | 3.3    | 1.8    | 3.2 | YES |
 | 3.3    | 1.8    | 3.3 | YES |
 | 3.3    | 1.8    | 3.4 | YES |
-| 3.3    | 1.9    | 3.1 | NO<sup>1,2</sup> |
-| 3.3    | 1.9    | 3.2 | NO<sup>2</sup> |
-| 3.3    | 1.9    | 3.3 | NO<sup>2</sup> |
-| 3.3    | 1.9    | 3.4 | NO<sup>2,4</sup> |
-| 3.4    | 1.7    | 3.1 | YES |
-| 3.4    | 1.7    | 3.2 | YES |
-| 3.4    | 1.7    | 3.3 | YES |
-| 3.4    | 1.7    | 3.3 | NO<sup>4</sup> |
+| 3.3    | 1.9    | x.x | NO<sup>2</sup> |
+| 3.3    | 1.10   | x.x | NO<sup>4</sup> |
+| 3.3    | 1.11   | x.x | NO<sup>5</sup> |
 | 3.4    | 1.8    | 3.1 | YES |
 | 3.4    | 1.8    | 3.2 | YES |
 | 3.4    | 1.8    | 3.3 | YES |
@@ -649,14 +640,14 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 3.4    | 1.9    | 3.2 | YES |
 | 3.4    | 1.9    | 3.3 | YES |
 | 3.4    | 1.9    | 3.4 | YES |
-| 3.4    | 1.10   | 3.2 | NO<sup>5</sup> |
-| 3.4    | 1.10   | 3.3 | NO<sup>5</sup> |
+| 3.4    | 1.10   | 3.2 | NO<sup>3</sup> |
+| 3.4    | 1.10   | 3.3 | NO<sup>3</sup> |
 | 3.4    | 1.10   | 3.4 | YES |
 | 3.4    | 1.10   | 3.5 | YES |
-| 3.5    | 1.7    | 3.1 | NO<sup>3</sup> |
-| 3.5    | 1.7    | 3.2 | NO<sup>3</sup> |
-| 3.5    | 1.7    | 3.3 | NO<sup>3</sup> |
-| 3.5    | 1.7    | 3.4 | NO<sup>3,4</sup> |
+| 3.4    | 1.10   | 3.6 | YES |
+| 3.4    | 1.11   | 3.3 | NO<sup>3</sup> |
+| 3.4    | 1.11   | 3.4 | YES |
+| 3.4    | 1.11   | 3.5 | YES |
 | 3.5    | 1.8    | 3.1 | YES |
 | 3.5    | 1.8    | 3.2 | YES |
 | 3.5    | 1.8    | 3.3 | YES |
@@ -665,17 +656,20 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 | 3.5    | 1.9    | 3.2 | YES |
 | 3.5    | 1.9    | 3.3 | YES |
 | 3.5    | 1.9    | 3.4 | YES |
-| 3.5    | 1.10   | 3.2 | NO<sup>5</sup> |
-| 3.5    | 1.10   | 3.3 | NO<sup>5</sup> |
+| 3.5    | 1.10   | 3.2 | NO<sup>3</sup> |
+| 3.5    | 1.10   | 3.3 | NO<sup>3</sup> |
 | 3.5    | 1.10   | 3.4 | YES |
 | 3.5    | 1.10   | 3.5 | YES |
+| 3.5    | 1.10   | 3.6 | YES |
+| 3.5    | 1.11   | 3.4 | YES |
+| 3.5    | 1.11   | 3.5 | YES |
+| 3.5    | 1.11   | 3.6 | YES |
 
 * 1: Django 1.9 is not compatible with DRF 3.1
 * 2: Django 1.9 is not compatible with Python 3.3
-* 3: Django 1.7 is not compatible with Python 3.5
-* 4: Django 1.7 is not compatible with DRF 3.4
-* 5: Django 1.10 is only compatible with DRF 3.4+
-
+* 3: Django 1.10 is only compatible with DRF 3.4+
+* 4: Django 1.10 is requires Python 2.7, 3.4, 3.5
+* 5: Django 1.11 is requires Python 2.7, 3.4, 3.5, 3.6
 # Contributing
 
 See [Contributing](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -668,8 +668,8 @@ Not all versions of Python, Django, and DRF are compatible. Here are the combina
 * 1: Django 1.9 is not compatible with DRF 3.1
 * 2: Django 1.9 is not compatible with Python 3.3
 * 3: Django 1.10 is only compatible with DRF 3.4+
-* 4: Django 1.10 is requires Python 2.7, 3.4, 3.5
-* 5: Django 1.11 is requires Python 2.7, 3.4, 3.5, 3.6
+* 4: Django 1.10 requires Python 2.7, 3.4, 3.5
+* 5: Django 1.11 requires Python 2.7, 3.4, 3.5, 3.6
 # Contributing
 
 See [Contributing](CONTRIBUTING.md).

--- a/README.rst
+++ b/README.rst
@@ -41,5 +41,5 @@ Requirements
 ============
 
 -  Python (2.7, 3.3, 3.4, 3.5)
--  Django (1.7, 1.8, 1.9, 1.10)
+-  Django (1.8, 1.9, 1.10, 1.11)
 -  Django REST Framework (3.1, 3.2, 3.3, 3.4, 3.5)

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
 Django>=1.8,<=1.11
-djangorestframework>=3.1.0,<3.6.2
+djangorestframework>=3.1.0,<=3.6.2
 inflection==0.3.1
 requests

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
-Django>=1.7,<1.11
-djangorestframework>=3.1.0,<3.6.0
+Django>=1.8,<=1.11
+djangorestframework>=3.1.0,<3.6.2
 inflection==0.3.1
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==1.3.4
 dj-database-url==0.3.0
-django-debug-toolbar==1.5
+django-debug-toolbar==1.7
 flake8==2.4.0
 pytest-cov==1.8.1
 pytest-django==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==1.3.4
 dj-database-url==0.3.0
-django-debug-toolbar==1.4
+django-debug-toolbar==1.5
 flake8==2.4.0
 pytest-cov==1.8.1
 pytest-django==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Adds Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '1.6.4'
+VERSION = '1.6.5'
 SCRIPTS = ['manage.py']
 
 setup(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,11 +51,6 @@ REST_FRAMEWORK = {
 
 ROOT_URLCONF = 'tests.urls'
 
-
-TEMPLATE_DIRS = (
-    os.path.abspath(os.path.join(BASE_DIR, '../dynamic_rest/templates')),
-)
-
 STATICFILES_DIRS = (
     os.path.abspath(os.path.join(BASE_DIR, '../dynamic_rest/static')),
 )
@@ -63,8 +58,9 @@ STATICFILES_DIRS = (
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': TEMPLATE_DIRS,
-        'APP_DIRS': True
+        'DIRS': os.path.abspath(os.path.join(BASE_DIR,
+                                '../dynamic_rest/templates')),
+        'APP_DIRS': True,
     }
 ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,7 +21,7 @@ else:
     # local sqlite database file
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': INSTALL_DIR + 'db.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
         'USER': '',
         'PASSWORD': '',
         'HOST': '',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,7 +28,9 @@ else:
         'PORT': ''
     }
 
-MIDDLEWARE_CLASSES = ()
+MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware'
+]
 
 INSTALLED_APPS = (
     'rest_framework',

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
        py27-lint,
        {py27,py33,py34,py35}-django18-drf{31,32,33,34},
        {py27,py34,py35}-django19-drf{32,33,34},
-       {py27,py34,py35}-django110-drf34,
-       {py27,py34,py35}-django110-drf35,
+       {py27,py34,py35}-django110-drf{34,35,36},
+       {py27,py34,py35}-django111-drf{34,35,36},
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
@@ -17,11 +17,13 @@ deps =
         django18: Django==1.8.14
         django19: Django==1.9.9
         django110: Django==1.10.0
+        django111: Django==1.11.0
         drf31: djangorestframework==3.1.0
         drf32: djangorestframework==3.2.0
         drf33: djangorestframework==3.3.0
         drf34: djangorestframework==3.4.0
         drf35: djangorestframework==3.5.0
+        drf36: djangorestframework==3.6.2
         -rrequirements.txt
 
 [testenv:py27-lint]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ addopts=--tb=short
 [tox]
 envlist =
        py27-lint,
-       {py27,py33,py34}-django17-drf{31,32,33},
        {py27,py33,py34,py35}-django18-drf{31,32,33,34},
        {py27,py34,py35}-django19-drf{32,33,34},
        {py27,py34,py35}-django110-drf34,
@@ -15,7 +14,6 @@ commands = ./runtests.py --fast {posargs} --coverage -rw
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-        django17: Django==1.7.11
         django18: Django==1.8.14
         django19: Django==1.9.9
         django110: Django==1.10.0


### PR DESCRIPTION
I tried to run through the tutorial and I had lots of trouble because of legacy support and lack of updated support. This is documented in a detailed way in the commit messages, the highlights are:
* Django 1.7 is deprecated so I removed support for it from tox and docs
* django-debug-toolbar 1.4 incompatible with current sqlparse version (1.4 requires 0.1.x, need >=1.5 for 0.2x)
* BONUS: Django 1.11 is out! Added test configs to tox for Django 1.11 as well as REST 3.6
* Moved default location for db.sqlite3 (in the tutorial) so that it is not in a location that requires superuser privileges on linux
