### PR TITLE
Add a method for getting the serializer from an instance, so that

### DIFF
--- a/dynamic_rest/fields/generic.py
+++ b/dynamic_rest/fields/generic.py
@@ -63,13 +63,16 @@ class DynamicGenericRelationField(
             'id': id_value
         }
 
+    def get_serializer_class_for_instance(self, instance):
+        return DynamicRouter.get_canonical_serializer(
+            resource_key=None,
+            instance=instance
+        )
+
     def to_representation(self, instance):
         try:
             # Find serializer for the instance
-            serializer_class = DynamicRouter.get_canonical_serializer(
-                resource_key=None,
-                instance=instance
-            )
+            serializer_class = self.get_serializer_class_for_instance(instance)
             if not serializer_class:
                 # Can't find canonical serializer! For now, just return
                 # object name and ID, and hope the client knows what to do


### PR DESCRIPTION
clients can override this if desired (to mock a generic relation, for
example)

Because we're pushing everything to `StudentCard`, in v4 API we still want `v4/evidences/?include[]=content_object.` to sideload using the correct serializer. In vishnu-backend we override the method provided here to accomplish that. https://github.com/AltSchool/vishnu-backend/pull/4046