### PR TITLE
Fixed sphinx's python path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@
 import os
 import sys
 
+# Add dynamic-rest project dir to python path for DJANGO_SETTINGS_MODULE="tests.settings" to work
+sys.path.insert(0, os.path.abspath('../'))
+
 import django
 
 django.setup()


### PR DESCRIPTION
I don't know about the setup you guys are using, but if I clone a fresh copy of dynamic-rest and run `make docs` you get a `ModuleNotFoundError: No module named 'tests.settings'`. This PR fixes that by adding the relative path to the dynamic-rest project to sys.path in sphinx's `conf.py`