### PR TITLE
Fix sideloading ADDITIONAL_PRIMARY_RESOURCE

### DIFF
--- a/dynamic_rest/processors.py
+++ b/dynamic_rest/processors.py
@@ -120,7 +120,7 @@ class SideloadingProcessor(object):
                     self.data[name].append(obj)
                 else:
                     # obj sideloaded, but maybe with other fields
-                    for o in self.data[name]:
+                    for o in self.data.get(name, []):
                         if o.instance.pk == pk:
                             o.update(obj)
                             break


### PR DESCRIPTION
My last pull request: https://github.com/AltSchool/dynamic-rest/pull/187
 contains small bug when you try sideload the same object as primary resource as ADDITIONAL_PRIMARY_RESOURCE. 

https://cl.ly/3D3N0J2q1z0U

