### PR TITLE
Add import statement

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -251,6 +251,8 @@ DREST-ifying Existing Serializer
 --------------------------------
 As with ViewSets, there’s a mixin to DREST-ify an existing serializer. Same shenanigans warning applies as above::
 
+    from dynamic_rest.serializers import WithDynamicModelSerializerMixin
+
     class NewFooSerializer(WithDynamicModelSerializerMixin, OldFooSerializer):
         # Must override Meta class with DREST attributes
         class Meta:


### PR DESCRIPTION
Add import statement for WithDynamicModelSerializerMixin
The example for DREST-ifying Existing Serializer does not have an import statment. 
New developers with the package would have to lookup the module for WithDynamicModelSerializerMixin.