### PR TITLE
Allow view to inject additional filters in such a way that avoids this

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ integration: install lint
 
 test_just: install lint
 	$(call header,"Running unit tests")
-	@$(INSTALL_DIR)/bin/py.test --cov=$(APP_NAME) -k $(TEST)
+	@$(INSTALL_DIR)/bin/py.test --cov=$(APP_NAME) -k $(TEST) --ignore=build --ignore=benchmarks
 
 # Run all tests (tox)
 tox: install

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -189,7 +189,7 @@ class DynamicFilterBackend(BaseFilterBackend):
         # running into https://code.djangoproject.com/ticket/18437
         # which, without this, would mean that filters added to the queryset
         # after this is called may not behave as expected
-        extra_filters = getattr(self.view, 'extra_drest_filters', None)
+        extra_filters = self.view.get_extra_filters(request)
 
         self.DEBUG = settings.DEBUG
         return self._build_queryset(

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -60,6 +60,13 @@ class WithDynamicViewSetMixin(object):
     Attributes:
       features: A list of features supported by the viewset.
       meta: Extra data that is added to the response by the DynamicRenderer.
+
+      extra_filters:
+        Add this to the view to enable addition of extra filters (i.e., a Q())
+        so custom filters can be added to the queryset without
+        running into https://code.djangoproject.com/ticket/18437
+        which, without this, would mean that filters added to the queryset
+        after this is called may not behave as expected.
     """
 
     DEBUG = 'debug'
@@ -85,6 +92,7 @@ class WithDynamicViewSetMixin(object):
         SIDELOADING
     )
     meta = None
+    extra_filters = None
     filter_backends = (DynamicFilterBackend, DynamicSortingFilter)
 
     def initialize_request(self, request, *args, **kargs):

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -60,13 +60,6 @@ class WithDynamicViewSetMixin(object):
     Attributes:
       features: A list of features supported by the viewset.
       meta: Extra data that is added to the response by the DynamicRenderer.
-
-      extra_filters:
-        Add this to the view to enable addition of extra filters (i.e., a Q())
-        so custom filters can be added to the queryset without
-        running into https://code.djangoproject.com/ticket/18437
-        which, without this, would mean that filters added to the queryset
-        after this is called may not behave as expected.
     """
 
     DEBUG = 'debug'
@@ -92,7 +85,6 @@ class WithDynamicViewSetMixin(object):
         SIDELOADING
     )
     meta = None
-    extra_filters = None
     filter_backends = (DynamicFilterBackend, DynamicSortingFilter)
 
     def initialize_request(self, request, *args, **kargs):
@@ -391,6 +383,14 @@ class WithDynamicViewSetMixin(object):
             return Response({}, status=200)
 
         return Response(serializer.data)
+
+    def get_extra_filters(self, request):
+        # Override this method to enable addition of extra filters
+        # (i.e., a Q()) so custom filters can be added to the queryset without
+        # running into https://code.djangoproject.com/ticket/18437
+        # which, without this, would mean that filters added to the queryset
+        # after this is called may not behave as expected.
+        return None
 
 
 class DynamicModelViewSet(WithDynamicViewSetMixin, viewsets.ModelViewSet):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -16,6 +16,7 @@ router.register_resource(viewsets.HorseViewSet)
 router.register_resource(viewsets.PermissionViewSet)
 router.register(r'zebras', viewsets.ZebraViewSet)  # not canonical
 router.register(r'user_locations', viewsets.UserLocationViewSet)
+router.register(r'alternate_locations', viewsets.AlternateLocationViewSet)
 
 # the above routes are duplicated to test versioned prefixes
 router.register_resource(viewsets.CatViewSet, namespace='v2')  # canonical

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -110,19 +110,18 @@ class AlternateLocationViewSet(DynamicModelViewSet):
     queryset = Location.objects.all()
 
     def filter_queryset(self, queryset):
-        user_name = self.request.query_params.get('user_name')
         user_name_separate_filter = self.request.query_params.get(
-            'user_name_separate',
+            'user_name_separate'
         )
-        if user_name:
-            self.extra_drest_filters = Q(
-                user__name=user_name,
-            )
-
         if user_name_separate_filter:
             queryset = queryset.filter(user__name=user_name_separate_filter)
-
         return super(AlternateLocationViewSet, self).filter_queryset(queryset)
+
+    def get_extra_filters(self, request):
+        user_name = request.query_params.get('user_name')
+        if user_name:
+            return Q(user__name=user_name)
+        return None
 
 
 class UserLocationViewSet(DynamicModelViewSet):

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -1,4 +1,5 @@
 from rest_framework import exceptions
+from django.db.models import Q
 
 from dynamic_rest.viewsets import DynamicModelViewSet
 from tests.models import (
@@ -101,6 +102,27 @@ class LocationViewSet(DynamicModelViewSet):
     model = Location
     serializer_class = LocationSerializer
     queryset = Location.objects.all()
+
+
+class AlternateLocationViewSet(DynamicModelViewSet):
+    model = Location
+    serializer_class = LocationSerializer
+    queryset = Location.objects.all()
+
+    def filter_queryset(self, queryset):
+        user_name = self.request.query_params.get('user_name')
+        user_name_separate_filter = self.request.query_params.get(
+            'user_name_separate',
+        )
+        if user_name:
+            self.extra_drest_filters = Q(
+                user__name=user_name,
+            )
+
+        if user_name_separate_filter:
+            queryset = queryset.filter(user__name=user_name_separate_filter)
+
+        return super(AlternateLocationViewSet, self).filter_queryset(queryset)
 
 
 class UserLocationViewSet(DynamicModelViewSet):


### PR DESCRIPTION
Django feature: https://code.djangoproject.com/ticket/18437

The issue is that these two querysets are not the same: 

`MasterCard.objects.filter(student_cards__is_archived=False).filter(student_cards__creator=<>)`
`MasterCard.objects.filter(student_cards__is_archived=False, student_cards__creator=<>)`

In the former, the `student_card` table is joined to `master_card` twice, and each join is filtered, whereas in the latter, `student_card` is joined once.

DREST takes all standard drest filters and wraps them into a single `filter` call, but adding custom filters outside of DREST ends up being a separate `filter` call, making it easy to run into this issue.

I've run into this a few times and thought it would make sense to allow callers a way to add filters into the DREST `filter` call, thus sidestepping this issue.

@ryochiji thought you might be the best candidate to review this. 

CC - @magistrula, this is my approach to the issue we ran into in this refactor https://github.com/AltSchool/vishnu-backend/pull/4744