### PR TITLE
Fix failing builds: django-debug-toolbar specifies Django>=1.8, which

### DIFF
--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
 Django>=1.8,<1.12
-djangorestframework>=3.1.0,<3.7
+djangorestframework>=3.1.0,<=3.6.3
 inflection==0.3.1
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Sphinx==1.3.4
 dj-database-url==0.3.0
-django-debug-toolbar==1.7
 flake8==2.4.0
 pytest-cov==1.8.1
 pytest-django==2.8.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,17 +28,12 @@ else:
         'PORT': ''
     }
 
-MIDDLEWARE = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware'
-]
-
 INSTALLED_APPS = (
     'rest_framework',
     'django.contrib.staticfiles',
     'django.contrib.contenttypes',
     'django.contrib.auth',
     'django.contrib.sites',
-    'debug_toolbar',
     'dynamic_rest',
     'tests',
 )


### PR DESCRIPTION
includes Django 2.0 which requires python 3. DRF 3.6.4 fails on tests
currently so pin that as well

django-debug-toolbar: https://github.com/jazzband/django-debug-toolbar/blob/1.7/setup.py#L18, and Django 2.0 was released Dec 2017 which is why we didn't see this until now.

Also DRF 3.6.4 causes this repo to fail on one test:

```
tests/test_api.py:1507: in test_get_list
    response = self.client.get('/users/?format=api')
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/test.py:282: in get
    response = super(APIClient, self).get(path, data=data, **extra)
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/test.py:208: in get
    return self.generic('GET', path, **r)
build/lib/python2.7/site-packages/django/test/client.py:416: in generic
    return self.request(**r)
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/test.py:279: in request
    return super(APIClient, self).request(**kwargs)
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/test.py:231: in request
    request = super(APIRequestFactory, self).request(**kwargs)
build/lib/python2.7/site-packages/django/test/client.py:501: in request
    six.reraise(*exc_info)
build/lib/python2.7/site-packages/django/core/handlers/exception.py:41: in inner
    response = get_response(request)
build/lib/python2.7/site-packages/django/core/handlers/base.py:217: in _get_response
    response = self.process_exception_by_middleware(e, request)
build/lib/python2.7/site-packages/django/core/handlers/base.py:215: in _get_response
    response = response.render()
build/lib/python2.7/site-packages/django/template/response.py:107: in render
    self.content = self.rendered_content
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/response.py:72: in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/renderers.py:706: in render
    context = self.get_context(data, accepted_media_type, renderer_context)
dynamic_rest/renderers.py:16: in get_context
    context
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/renderers.py:639: in get_context
    raw_data_post_form = self.get_raw_data_form(data, view, 'POST', request)
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/renderers.py:559: in get_raw_data_form
    data = {k: v for (k, v) in serializer.data.items()
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/renderers.py:560: in <dictcomp>
    if not isinstance(serializer.fields[k],
build/lib/python2.7/site-packages/djangorestframework-3.6.4-py2.7.egg/rest_framework/utils/serializer_helpers.py:148: in __getitem__
    return self.fields[key]
E   KeyError: 'user'
```

This is because `serializer.data` (for `UserSerializer`) ends up being nested by `user`. I don't see anything in the [DRF 3.6.4 release notes](https://github.com/encode/django-rest-framework/blob/master/docs/topics/release-notes.md#364) that explain this change, though.
  