### PR TITLE
[FastQuery] Use proper pk attribute names

### DIFF
--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -192,7 +192,7 @@ class FastQuery(FastQueryCompatMixin, object):
         self.model = queryset.model
         self.prefetches = {}
         self.fields = None
-        self.pk_field = queryset.model._meta.pk.name
+        self.pk_field = queryset.model._meta.pk.attname
         self._data = None
         self._my_ids = None
 

--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -289,7 +289,7 @@ class FastQuery(FastQueryCompatMixin, object):
 
     def _get_my_ids(self, data):
         if self._my_ids is None:
-            pk_field = self.queryset.model._meta.pk.name
+            pk_field = self.queryset.model._meta.pk.attname
             self._my_ids = {o[pk_field] for o in data}
 
         return self._my_ids

--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -368,7 +368,7 @@ class FastQuery(FastQueryCompatMixin, object):
         my_ids = self._get_my_ids(data)
 
         base_qs = prefetch.query.queryset  # base queryset on remote model
-        remote_pk_field = base_qs.model._meta.pk.name  # get pk field name
+        remote_pk_field = base_qs.model._meta.pk.attname  # get pk field name
         reverse_field = reverse_m2m_field_name(field)
 
         if reverse_field is None:


### PR DESCRIPTION
Use `pk.attname` instead of `pk.name`, since `attname` resolves to the actual column name (and hence the right key for the `dict` representation of the model)