### PR TITLE
[FastQuery] Support for DynamicGenericRelationField

### DIFF
--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -55,7 +55,7 @@ class FastPrefetch(object):
         if isinstance(queryset, QuerySet):
             queryset = FastQuery(queryset)
 
-        assert isinstance(queryset, FastQuery)
+        assert (queryset is None or isinstance(queryset, FastQuery))
 
         self.field = field
         self.query = queryset

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -582,9 +582,11 @@ class WithDynamicSerializerMixin(
                         if hasattr(instance, field.source):
                             attribute = getattr(instance, field.source)
                         else:
-                            print 'Missing %s from %s' % (
-                                field.field_name,
-                                self.__class__.__name__
+                            print(
+                                'Missing %s from %s' % (
+                                    field.field_name,
+                                    self.__class__.__name__
+                                )
                             )
             else:
                 try:

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -18,7 +18,10 @@ from dynamic_rest.bases import (
     resettable_cached_property
 )
 from dynamic_rest.conf import settings
-from dynamic_rest.fields import DynamicRelationField
+from dynamic_rest.fields import (
+    DynamicRelationField,
+    DynamicGenericRelationField,
+)
 from dynamic_rest.links import merge_link_object
 from dynamic_rest.meta import get_model_table
 from dynamic_rest.processors import SideloadingProcessor
@@ -564,7 +567,7 @@ class WithDynamicSerializerMixin(
         id_fields = self._readable_id_fields
 
         for field in fields:
-            if is_fast:
+            if is_fast and not isinstance(field, DynamicGenericRelationField):
                 if field in id_fields and field.source not in instance:
                     # TODO - make better.
                     attribute = instance.get(field.source + '_id')


### PR DESCRIPTION
Adds compatibility with `DynamicGenericRelationField`, which provides no queryset to `Prefetch`