### PR TITLE
only fetch all fields in DynamicSerializer._dynamic_init() if needed

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -278,7 +278,6 @@ class WithDynamicSerializerMixin(
         only_fields = set(only_fields or [])
         include_fields = include_fields or []
         exclude_fields = exclude_fields or []
-        all_fields = set(self.get_all_fields().keys())
 
         if only_fields:
             exclude_fields = '*'
@@ -292,8 +291,10 @@ class WithDynamicSerializerMixin(
                     if val or val == {}
                 ]
             )
+            all_fields = set(self.get_all_fields().keys())  # this is slow
             exclude_fields = all_fields - include_fields
         elif include_fields == '*':
+            all_fields = set(self.get_all_fields().keys())  # this is slow
             include_fields = all_fields
 
         for name in exclude_fields:


### PR DESCRIPTION
In `DynamicSerializer._dynamic_init()` (which gets called every time a `DynamicModelSerializer` gets instantiated), there's a call to `field.get_all_fields()` that gets called even when not necessary (e.g. cases where the serializer is in `id_only` mode and we don't need to know about other fields). This PR moves the slow line to the cases where it's actually needed. See profiler output below:

**Before**
<img width="1214" alt="screen shot 2018-01-30 at 5 15 08 pm" src="https://user-images.githubusercontent.com/172724/35600350-47cfbc64-05e2-11e8-95df-825c084fdbba.png">

**After**
<img width="1214" alt="screen shot 2018-01-30 at 5 15 13 pm" src="https://user-images.githubusercontent.com/172724/35600351-47e929f6-05e2-11e8-811a-5a09049d5fb0.png">
