### PR TITLE
Fix/fastquery get prefetch bug

### DIFF
--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -207,8 +207,9 @@ class FastQueryCompatMixin(object):
         # Convert FastPrefetches back to Django Prefetch objects
         prefetches = []
         for field, fprefetch in self.prefetches.items():
+            qs = fprefetch.query.queryset if fprefetch.query else None
             prefetches.append(
-                Prefetch(field, queryset=fprefetch.query.queryset)
+                Prefetch(field, queryset=qs)
             )
 
         queryset = self.queryset

--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import copy
+import traceback
 
 from django.db import models
 from django.db.models import Prefetch, QuerySet
@@ -167,8 +168,7 @@ class FastQueryCompatMixin(object):
                     )
                 self.prefetches[arg.field] = arg
         except Exception as e:  # noqa
-            import pdb
-            pdb.set_trace()
+            traceback.print_exc()
 
         return self
 
@@ -204,7 +204,19 @@ class FastQueryCompatMixin(object):
         return self
 
     def get(self, *args,  **kwargs):
-        return self.queryset.get(*args, **kwargs)
+        # Convert FastPrefetches back to Django Prefetch objects
+        prefetches = []
+        for field, fprefetch in self.prefetches.items():
+            prefetches.append(
+                Prefetch(field, queryset=fprefetch.query.queryset)
+            )
+
+        queryset = self.queryset
+        if prefetches:
+            queryset = queryset.prefetch_related(*prefetches)
+
+        # Returns ORM object
+        return queryset.get(*args, **kwargs)
 
     def first(self, *args, **kwargs):
         return self.queryset.first()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Adds Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '1.7.1'
+VERSION = '1.7.2'
 SCRIPTS = ['manage.py']
 
 setup(

--- a/tests/test_prefetch2.py
+++ b/tests/test_prefetch2.py
@@ -3,7 +3,7 @@ import six
 from rest_framework.test import APITestCase
 
 from dynamic_rest.prefetch import FastPrefetch, FastQuery
-from tests.models import Group, Location, Profile, User
+from tests.models import Group, Location, Profile, User, Cat
 from tests.setup import create_fixture
 
 
@@ -168,3 +168,18 @@ class TestPrefetch(APITestCase):
 
         self.assertTrue('user_set' in out[0])
         self.assertTrue('groups' in out[0]['user_set'][0])
+
+    def test_get_with_prefetch(self):
+        # FastQuery.get() should apply prefetch filters correctly
+        self.assertTrue(
+            Cat.objects.filter(home=1, backup_home=3).exists()
+        )
+        q = FastQuery(Location.objects.all())
+        q.prefetch_related(
+            FastPrefetch(
+                'friendly_cats',
+                Cat.objects.filter(home__gt=1)
+            )
+        )
+        obj = q.get(pk=3)
+        self.assertFalse(obj.friendly_cats.count())


### PR DESCRIPTION
On endpoints with FastQuery enabled, sideload filtering wasn't working properly for single-object retrieval and link requests. This fixes that issue.