### PR TITLE
fix circle builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ dependencies:
     override:
         - pip install -r requirements.txt
         - python setup.py develop
+        - pyenv versions
         - pyenv install -s 2.7.10
         - pyenv install -s 3.3.3
         - pyenv install -s 3.4.3
         - pyenv install -s 3.5.0
-        - pyenv install -s 3.6.3
-        - pyenv local 2.7.10 3.3.3 3.4.3 3.5.0 3.6.3
+        - pyenv local 2.7.10 3.3.3 3.4.3 3.5.0
 
 test:
     override:

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ addopts=--tb=short
 [tox]
 envlist =
        py27-lint,
-       {py27,py33,py34,py35,py36}-django18-drf{31,32,33,34},
-       {py27,py34,py35,py36}-django111-drf{34,35,36,37},
-       {py35,py36}-django20-drf37,
+       {py27,py33,py34,py35}-django18-drf{31,32,33,34},
+       {py27,py34,py35}-django111-drf{34,35,36,37},
+       {py35}-django20-drf37,
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw


### PR DESCRIPTION
Tox tests for python 3.6 are failing on Circle. Remove for now.