### PR TITLE
prevents execution of base query through accessing query attribute on…

### DIFF
--- a/dynamic_rest/prefetch.py
+++ b/dynamic_rest/prefetch.py
@@ -227,7 +227,8 @@ class FastQueryCompatMixin(object):
 
         prefetches = []
         for field, fprefetch in self.prefetches.items():
-            qs = fprefetch.query.queryset if fprefetch.query else None
+            has_query = hasattr(fprefetch, 'query')
+            qs = fprefetch.query.queryset if has_query else None
             prefetches.append(
                 Prefetch(field, queryset=qs)
             )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Adds Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '1.8.0'
+VERSION = '1.8.1'
 SCRIPTS = ['manage.py']
 
 setup(


### PR DESCRIPTION
… prefetch object
Accessing the `query` property on the prefetch object was causing the execution of the base query.

For example, a call to: `/table/1`, these queries would execute:
1. `SELECT DISTINCT "foo"."property" FROM "bar"`
1. `SELECT DISTINCT "foo"."property" FROM "bar" WHERE "foo"."id" IN ('1')`

This change will prevent the first execution

The separation of lines was to fit within character limit