### PR TITLE
cache serialized objects within a single context

### DIFF
--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -17,6 +17,12 @@ DYNAMIC_REST = {
     # ENABLE_SERIALIZER_CACHE: enable/disable caching of related serializers
     'ENABLE_SERIALIZER_CACHE': True,
 
+    # ENABLE_SERIALIZER_OBJECT_CACHE: enable/disable caching of serialized
+    # objects within a serializer instance/context. This can yield
+    # significant performance improvements in cases where the same objects
+    # are sideloaded repeatedly.
+    'ENABLE_SERIALIZER_OBJECT_CACHE': True,
+
     # ENABLE_SERIALIZER_OPTIMIZATIONS: enable/disable representation speedups
     'ENABLE_SERIALIZER_OPTIMIZATIONS': True,
 

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -671,8 +671,8 @@ class WithDynamicSerializerMixin(
         if self.id_only():
             return instance.pk
 
-        pk = instance.pk
-        if not settings.ENABLE_SERIALIZER_OBJECT_CACHE:
+        pk = getattr(instance, 'pk', None)
+        if not settings.ENABLE_SERIALIZER_OBJECT_CACHE or pk is None:
             return self._to_representation(instance)
         else:
             if pk not in self.obj_cache:

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -679,7 +679,6 @@ class WithDynamicSerializerMixin(
                 self.obj_cache[pk] = self._to_representation(instance)
             return self.obj_cache[pk]
 
-
     def to_internal_value(self, data):
         value = super(WithDynamicSerializerMixin, self).to_internal_value(data)
         id_attr = getattr(self.Meta, 'update_lookup_field', 'id')


### PR DESCRIPTION
Currently, we potentially serialize the same object over and over again when the same object instance appears many times (usually as sideloads).

For example, consider:
`/objectives/?include[]=subject.&include[]=rubric.rubric_items.`

There are actually only a handful of distinct subjects and a couple of sets of rubric/rubric items, but we re-serialize the subjects and rubrics for each objective. This PR introduces a cache that is tied to a specific serializer instance (which is shared within a single request context) to prevent such redundant serializations. (For that specific example above in our backend, this change reduces CPU usage by about half.)