### PR TITLE
Prevent `attribute` from leaking across loop iterations

### DIFF
--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -579,6 +579,7 @@ class WithDynamicSerializerMixin(
         id_fields = self._readable_id_fields
 
         for field in fields:
+            attribute = None
             # we exclude dynamic fields here because the proper fastquery
             # dereferencing happens in the `get_attribute` method now
             if (


### PR DESCRIPTION
Set `attribute` to `None` at the start of each loop to prevent it from leaking across iterations of the loop and being serialized as the wrong field.  This only happens under very specific circumstances--i.e. the ones that trigger the else block [here](https://github.com/AltSchool/dynamic-rest/blob/master/dynamic_rest/serializers.py#L604).

Alternatively, I can add a call to `get_attribute` there, since this generally should only happen with non-DynamicRest fields, and a call to `get_attribute` can act as a fallback.