### PR TITLE
Silence a github warning of a security vulnerability

### DIFF
--- a/requirements.benchmark.txt
+++ b/requirements.benchmark.txt
@@ -1,5 +1,5 @@
 Sphinx==1.3.4
-Django<2.0.0
+Django>=1.11.15<2.0.0
 dj-database-url==0.3.0
 django-debug-toolbar==1.7
 flake8==2.4.0


### PR DESCRIPTION
Django 1.11.8 & 1.11.9 had a security vulnerability, and github decided
it wasn't happy with us not excluding these versions from
requirements.benchmark.txt, so in order to silence that warning, we are excluding those versions. I used version 1.11.15 as the lower version because that's what we're currently using in `vishnu-backedn`. This is used only when running benchmarks, so the main purpose of this PR is to silence the github warning.