### PR TITLE
Updates to the py36-drf38 branch to fix errors that occur.

### DIFF
--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -1,4 +1,6 @@
 """This module contains custom pagination classes."""
+from collections import OrderedDict
+
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -28,8 +30,10 @@ class DynamicPageNumberPagination(PageNumberPagination):
 
     def get_paginated_response(self, data):
         meta = self.get_page_metadata()
-        if 'meta' in data:
-            data['meta'].update(meta)
-        else:
-            data['meta'] = meta
-        return Response(data)
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data),
+            ('meta', meta)
+        ]))

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -11,7 +11,7 @@ from django.utils import six
 from rest_framework import views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.routers import DefaultRouter, Route, replace_methodname
+from rest_framework.routers import DefaultRouter, Route
 
 from dynamic_rest.meta import get_model_table
 from dynamic_rest.conf import settings
@@ -19,6 +19,18 @@ from dynamic_rest.conf import settings
 directory = {}
 resource_map = {}
 resource_name_map = {}
+
+
+def replace_methodname(format_string, methodname):
+    """
+    Partially format a format_string, swapping out any
+    '{methodname}' or '{methodnamehyphen}' components.
+    """
+    methodnamehyphen = methodname.replace('_', '-')
+    ret = format_string
+    ret = ret.replace('{methodname}', methodname)
+    ret = ret.replace('{methodnamehyphen}', methodnamehyphen)
+    return ret
 
 
 def get_directory(request):
@@ -324,6 +336,7 @@ class DynamicRouter(DefaultRouter):
             routes.append(Route(
                 url=url,
                 mapping={'get': methodname},
+                detail=False,
                 name=replace_methodname(route_name, field_name),
                 initkwargs={}
             ))


### PR DESCRIPTION
DRF has removed the method `replace_methodname`. They've also added a kwarg to route `detail` to denote if a route is a detail or a list route. This PR address those necessary changes in that branch for compatibility.