### PR TITLE
add support for Transform on fields (year, month, day, etc)

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -122,17 +122,15 @@ class FilterNode(object):
             # and field.source would be None
             rewritten.append(model_field_name)
 
-            if i == last:
-                break
-
             # Recurse into nested field
-            s = getattr(field, 'serializer', None)
-            if isinstance(s, serializers.ListSerializer):
-                s = s.child
-            if not s:
-                raise ValidationError(
-                    "Invalid nested filter field: %s" % field_name
-                )
+            nested_serializer = getattr(field, 'serializer', None)
+            if nested_serializer:
+                if isinstance(nested_serializer, serializers.ListSerializer):
+                    nested_serializer = nested_serializer.child
+            else:
+                # this is not a nested field, but a Transform instead
+                rewritten.extend(self.field[i+1:])
+                break
 
         if self.operator:
             rewritten.append(self.operator)
@@ -161,10 +159,6 @@ class DynamicFilterBackend(BaseFilterBackend):
         'istartswith',
         'endswith',
         'iendswith',
-        'year',
-        'month',
-        'day',
-        'week_day',
         'regex',
         'range',
         'gt',


### PR DESCRIPTION
last support for these Transform was to treat them as operator, but
it prevented the use of transform AND operator (__year__gt=2018)

now, if a filter on a field hit a non-nested field, instead of raising
a validation error, it treat the spare parts as Transform and add them
to the final query. it's more flexible and allow support for custom
Transform along with support for JSONField