### PR TITLE
Fix FastQuery implicit prefetch bug

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -352,10 +352,13 @@ class DynamicFilterBackend(BaseFilterBackend):
 
         return prefetches
 
+    def _make_model_queryset(self, model):
+        return model.objects.all()
+
     def _build_implicit_queryset(self, model, requirements):
         """Build a queryset based on implicit requirements."""
 
-        queryset = model.objects.all()
+        queryset = self._make_model_queryset(model)
         prefetches = {}
         self._build_implicit_prefetches(
             model,
@@ -619,6 +622,12 @@ class FastDynamicFilterBackend(DynamicFilterBackend):
             queryset = FastQuery(queryset)
 
         return queryset
+
+    def _make_model_queryset(self, model):
+        queryset = super(FastDynamicFilterBackend, self)._make_model_queryset(
+            model
+        )
+        return FastQuery(queryset)
 
     def _serializer_filter(self, serializer=None, queryset=None):
         queryset.queryset = serializer.filter_queryset(


### PR DESCRIPTION
There was a bug in how we built [implicit prefetches](https://github.com/AltSchool/dynamic-rest/blob/33eba354857720ea6489b5481570a298442b3257/dynamic_rest/filters.py#L327) with FastQuery enabled, where for nested prefetches (i.e. prefetches that themselves have prefetches) the first layer was a [Django QuerySet](https://github.com/AltSchool/dynamic-rest/blob/33eba354857720ea6489b5481570a298442b3257/dynamic_rest/filters.py#L358) but then we were [adding FastPrefetch](https://github.com/AltSchool/dynamic-rest/blob/33eba354857720ea6489b5481570a298442b3257/dynamic_rest/filters.py#L348) objects to them (turns out Django's `QuerySet.prefetch_related()` [doesn't do any validation](https://github.com/django/django/blob/stable/1.11.x/django/db/models/query.py#L901)). That caused QuerySet evaluation (e.g. [here](https://github.com/AltSchool/dynamic-rest/blob/33eba354857720ea6489b5481570a298442b3257/dynamic_rest/prefetch.py#L296)) to explode in really opaque ways[1].

This fix ensures we create a FastQuery object rather than a Django QuerySet object for implicit prefetches, if FastQuery is enabled.

[1] - For the truly curious, it blows up [here](https://github.com/django/django/blob/stable/1.11.x/django/db/models/query.py#L1418) where `lookup.prefetch_through.split` fails because `lookup.prefetch_through` is a FastQuery object. Why? Because Django [assumes](https://github.com/django/django/blob/stable/1.11.x/django/db/models/query.py#L1378) that any prefetch that isn't a Prefetch object is a string. But what's opaque about it is that the error doesn't occur until you try to iterate on the queryset, and in this specific case it happened inside a `map` call that caught it and threw a different error.