### PR TITLE
Leave rest_framework router is unmodified

### DIFF
--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -1,4 +1,5 @@
 """This module contains custom router classes."""
+import copy
 from collections import OrderedDict
 
 # Backwards compatability for django < 1.10.x
@@ -75,7 +76,7 @@ def modify_list_route(routes):
 
 
 class DynamicRouter(DefaultRouter):
-    routes = list(DefaultRouter.routes)
+    routes = copy.deepcopy(DefaultRouter.routes)
     modify_list_route(routes)
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -6,9 +6,10 @@ except ImportError:
 
 
 from rest_framework.test import APITestCase
+from rest_framework.routers import DefaultRouter
 
 from dynamic_rest.meta import get_model_table
-from dynamic_rest.routers import DynamicRouter
+from dynamic_rest.routers import DynamicRouter, Route
 from tests.models import Dog
 from tests.serializers import CatSerializer, DogSerializer
 from tests.urls import urlpatterns  # noqa  force route registration
@@ -68,4 +69,18 @@ class TestDynamicRouter(APITestCase):
         self.assertEqual(
             DogSerializer,
             DynamicRouter.get_canonical_serializer(None, instance=dog)
+        )
+
+    def test_rest_framework_router_unmodified(self):
+        if hasattr(self, 'assertCountEqual'):
+            method = self.assertCountEqual
+        else:
+            method = self.assertItemsEqual
+
+        method(
+            [
+                {'post': 'create', 'get': 'list'},
+                {'put': 'update', 'patch': 'partial_update', 'delete': 'destroy', 'get': 'retrieve'}
+            ],
+            [route.mapping for route in DefaultRouter.routes if isinstance(route, Route)]
         )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -90,5 +90,8 @@ class TestDynamicRouter(APITestCase):
                     'get': 'retrieve'
                 }
             ],
-            [route.mapping for route in DefaultRouter.routes if isinstance(route, Route)]
+            [
+                route.mapping for route in DefaultRouter.routes
+                if isinstance(route, Route)
+            ]
         )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -79,8 +79,16 @@ class TestDynamicRouter(APITestCase):
 
         method(
             [
-                {'post': 'create', 'get': 'list'},
-                {'put': 'update', 'patch': 'partial_update', 'delete': 'destroy', 'get': 'retrieve'}
+                {
+                    'post': 'create',
+                    'get': 'list'
+                },
+                {
+                    'put': 'update',
+                    'patch': 'partial_update',
+                    'delete': 'destroy',
+                    'get': 'retrieve'
+                }
             ],
             [route.mapping for route in DefaultRouter.routes if isinstance(route, Route)]
         )


### PR DESCRIPTION
Right now it's doing a shallow copy of the routes and hence your monkeypatch affects the source of the data. This causes all routes to accept `PATCH` and `DETELE` requests which in turn causes this exception instead of returning a 405:

> AssertionError: Expected view {viewset} to be called with a URL keyword argument named "pk". Fix your URL conf, or set the `.lookup_field` attribute on the view correctly.