### PR TITLE
Add 'iexact' to available filters

### DIFF
--- a/docs/dynamic_rest.html
+++ b/docs/dynamic_rest.html
@@ -271,7 +271,7 @@ False by the isnull operator.</p>
 
 <dl class="attribute">
 <dt>
-<code class="descname">VALID_FILTER_OPERATORS</code><em class="property"> = ('in', 'any', 'all', 'icontains', 'contains', 'startswith', 'istartswith', 'endswith', 'iendswith', 'year', 'month', 'day', 'week_day', 'regex', 'range', 'gt', 'lt', 'gte', 'lte', 'isnull', 'eq', None)</em></dt>
+<code class="descname">VALID_FILTER_OPERATORS</code><em class="property"> = ('in', 'any', 'all', 'icontains', 'contains', 'startswith', 'istartswith', 'endswith', 'iendswith', 'year', 'month', 'day', 'week_day', 'regex', 'range', 'gt', 'lt', 'gte', 'lte', 'isnull', 'eq', 'iexact', None)</em></dt>
 <dd></dd></dl>
 
 <dl class="method">

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -173,6 +173,7 @@ class DynamicFilterBackend(BaseFilterBackend):
         'lte',
         'isnull',
         'eq',
+        'iexact',
         None,
     )
 


### PR DESCRIPTION
Hi, I have added 'iexact' to the list of available filters. 

https://docs.djangoproject.com/en/2.1/ref/models/querysets/#iexact