### PR TITLE
fix bug where implicit prefetch and explicit prefetch behaviors were …

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -518,6 +518,18 @@ class DynamicFilterBackend(BaseFilterBackend):
             requirements
         )
 
+        # Implicit requirements (i.e. via `requires`) can potentially
+        # include fields that haven't been explicitly included.
+        # Such fields would not be in `fields`, so they need to be added.
+        implicitly_included = set(requirements.keys()) - set(fields.keys())
+        if implicitly_included:
+            all_fields = serializer.get_all_fields()
+            fields.update({
+                field: all_fields[field]
+                for field in implicitly_included
+                if field in all_fields
+            })
+
         if filters is None:
             filters = self._get_requested_filters()
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -59,9 +59,6 @@ class LocationSerializer(DynamicModelSerializer):
             'cats', 'friendly_cats', 'bad_cats'
         )
 
-    def filter_queryset(self, query):
-        return query.exclude(name='Atlantis')
-
     users = DynamicRelationField(
         'UserSerializer',
         source='user_set',
@@ -76,6 +73,9 @@ class LocationSerializer(DynamicModelSerializer):
         'CatSerializer', many=True, deferred=True)
     bad_cats = DynamicRelationField(
         'CatSerializer', source='annoying_cats', many=True, deferred=True)
+
+    def filter_queryset(self, query):
+        return query.exclude(name='Atlantis')
 
 
 class PermissionSerializer(DynamicModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -59,11 +59,15 @@ class LocationSerializer(DynamicModelSerializer):
             'cats', 'friendly_cats', 'bad_cats'
         )
 
+    def filter_queryset(self, query):
+        return query.exclude(name='Atlantis')
+
     users = DynamicRelationField(
         'UserSerializer',
         source='user_set',
         many=True,
-        deferred=True)
+        deferred=True
+    )
     user_count = CountField('users', required=False, deferred=True)
     address = DynamicField(source='blob', required=False, deferred=True)
     cats = DynamicRelationField(


### PR DESCRIPTION
…inconsistent. Specifically, in the implicit prefetch scenario, the related serializer's `filter_queryset()` method wasn't being respected (because without that related field being included, part of the codepath didn't recognize it as a valid field).