### PR TITLE
Fix/links context bug

### DIFF
--- a/dynamic_rest/fields/fields.py
+++ b/dynamic_rest/fields/fields.py
@@ -251,13 +251,13 @@ class DynamicRelationField(WithRelationalFieldMixin, DynamicField):
         if self.embed and self._is_dynamic:
             init_args['embed'] = True
 
-        return self._get_cached_serializer(args, init_args)
+        serializer = self._get_cached_serializer(args, init_args)
+        serializer.parent = self
+        return serializer
 
     @resettable_cached_property
     def serializer(self):
-        serializer = self.get_serializer()
-        serializer.parent = self
-        return serializer
+        return self.get_serializer()
 
     @cached_property
     def _is_dynamic(self):

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -395,7 +395,6 @@ class WithDynamicViewSetMixin(object):
         # is we need to set `envelope=True` to get the sideload-processor
         # applied.
         related_szr = field.get_serializer(envelope=True)
-        related_szr.parent = field.parent  # ensures context is inherited
         try:
             # TODO(ryo): Probably should use field.get_attribute() but that
             #            seems to break a bunch of things. Investigate later.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Adds Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '1.9.6'
+VERSION = '1.9.7'
 SCRIPTS = ['manage.py']
 
 setup(

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -197,6 +197,9 @@ class UserSerializer(DynamicModelSerializer):
     favorite_pet = DynamicGenericRelationField(required=False)
 
     def get_number_of_cats(self, user):
+        if not self.context.get('request'):
+            # Used in test_api.py::test_relation_includes_context
+            raise Exception("No request object in context")
         location = user.location
         return len(location.cat_set.all()) if location else 0
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1152,6 +1152,16 @@ class TestRelationsAPI(APITestCase):
         content = json.loads(r.content.decode('utf-8'))
         self.assertTrue('locations' in content)
 
+    def test_relation_includes_context(self):
+        r = self.client.get('/locations/1/users/?include[]=number_of_cats')
+        self.assertEqual(200, r.status_code)
+
+        # Note: the DynamicMethodField for `number_of_cats` checks to
+        # ensure context is set, and raises if not. If the request
+        # succeeded and `number_of_cats` is returned, it means that check
+        # passed.
+        self.assertTrue('number_of_cats' in r.data['users'][0])
+
     def test_relation_excludes(self):
         r = self.client.get('/locations/1/users/?exclude[]=location')
         self.assertEqual(200, r.status_code)


### PR DESCRIPTION
Fixes bug where serializer context wasn't available in relational link endpoints. Main issue was that a new serializer was being created without being linked to the parent serializer, making the context unavailable (since context isn't stored in child serializers, but is rather [read from the root serializer](https://github.com/AltSchool/dynamic-rest/blob/master/dynamic_rest/bases.py#L58)).