### PR TITLE
[ALTOS-22468] add fix for sort by relation

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -667,8 +667,11 @@ class DynamicSortingFilter(OrderingFilter):
 
         ordering = self.get_ordering(request, queryset, view)
         if ordering:
-            return queryset.order_by(*ordering)
-
+            queryset = queryset.order_by(*ordering)
+            if any(['__' in o for o in ordering]):
+                # add distinct() to remove duplicates
+                # in case of order-by-related
+                queryset = queryset.distinct()
         return queryset
 
     def get_ordering(self, request, queryset, view):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -925,6 +925,15 @@ class TestUsersAPI(APITestCase):
             [row['location'] for row in data['users']]
         )
 
+    def test_sort_relation_field_many(self):
+        url = '/locations/?sort[]=friendly_cats.name'
+        response = self.client.get(url)
+        self.assertEquals(200, response.status_code)
+        data = json.loads(response.content.decode('utf-8'))
+        ids = [row['id'] for row in data['locations']]
+        # no duplicates
+        self.assertEquals(len(ids), len(set(ids)))
+
 
 @override_settings(
     DYNAMIC_REST={


### PR DESCRIPTION
When sorting by a related many-field, we need to call `distinct()` in order to remove duplicates