### PR TITLE
bump major version number since dropping py2 is a breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Adds Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '1.9.8'
+VERSION = '2.0.0'
 SCRIPTS = ['manage.py']
 
 setup(


### PR DESCRIPTION
https://github.com/AltSchool/dynamic-rest/pull/303 would cause this lib to break for people using py2, so bump the major version number prior to releasing