### PR TITLE
Fix filter by non-model fields

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -114,9 +114,10 @@ class FilterNode(object):
             # For remote fields, strip off '_set' for filtering. This is a
             # weird Django inconsistency.
             model_field_name = field.source or field_name
-            model_field = get_model_field(s.get_model(), model_field_name)
-            if isinstance(model_field, RelatedObject):
-                model_field_name = model_field.field.related_query_name()
+            if is_model_field(s.get_model(), model_field_name):
+                model_field = get_model_field(s.get_model(), model_field_name)
+                if isinstance(model_field, RelatedObject):
+                    model_field_name = model_field.field.related_query_name()
 
             # If get_all_fields() was used above, field could be unbound,
             # and field.source would be None


### PR DESCRIPTION
When filtering by non-model fields (e.g. annotated fields) FilterNode throws AttributeError because the field doesn't exist in the model. This simple if condition solves such broken path.