### PR TITLE
Use twine to upload packages to pypi and test pypi.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,13 @@ endef
 
 pypi_upload_test: install
 	$(call header,"Uploading new version to PyPi - test")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist twine upload --repository testpypi dist/*
+	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist
+	@twine upload --repository testpypi dist/*
 
 pypi_upload: install
 	$(call header,"Uploading new version to PyPi")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist twine upload dist/*
+	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist
+	@twine upload dist/*
 
 docs: install
 	$(call header,"Building docs")

--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,13 @@ endef
 
 .PHONY: docs
 
-pypi_register_test: install
-	$(call header,"Registering with PyPi - test")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py register -r pypitest
-
-pypi_register: install
-	$(call header,"Registering with PyPi")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py register -r pypi
-
 pypi_upload_test: install
 	$(call header,"Uploading new version to PyPi - test")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist upload -r pypitest
+	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist twine upload --repository testpypi dist/*
 
 pypi_upload: install
 	$(call header,"Uploading new version to PyPi")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist upload -r pypi
+	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist twine upload dist/*
 
 docs: install
 	$(call header,"Building docs")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.16.0
 Sphinx==1.7.5
 tox-pyenv==1.1.0
 tox==3.14.6
+twine==3.3.0


### PR DESCRIPTION
Remove registration commands from makefile, as pre-registration is no longer required and the pypi api no longer supports it