### PR TITLE
add new "exclude count" page number pagination option

### DIFF
--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -60,8 +60,8 @@ DYNAMIC_REST = {
     # Can be overriden at the viewset level.
     'PAGE_SIZE_QUERY_PARAM': 'per_page',
 
-    # EXCLUDE_COUNT_QUERY_PARAM: global setting for the query parameter that disables counts
-    # during pagination
+    # EXCLUDE_COUNT_QUERY_PARAM: global setting for the query parameter
+    # that disables counting during PageNumber pagination
     'EXCLUDE_COUNT_QUERY_PARAM': 'exclude_count',
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional

--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -60,10 +60,9 @@ DYNAMIC_REST = {
     # Can be overriden at the viewset level.
     'PAGE_SIZE_QUERY_PARAM': 'per_page',
 
-    # NO_COUNT_QUERY_PARAM: global setting for the query parameter that disables counts
+    # EXCLUDE_COUNT_QUERY_PARAM: global setting for the query parameter that disables counts
     # during pagination
-    # Can be overriden at the viewset level.
-    'NO_COUNT_QUERY_PARAM': 'exclude_count',
+    'EXCLUDE_COUNT_QUERY_PARAM': 'exclude_count',
 
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.

--- a/dynamic_rest/conf.py
+++ b/dynamic_rest/conf.py
@@ -60,6 +60,11 @@ DYNAMIC_REST = {
     # Can be overriden at the viewset level.
     'PAGE_SIZE_QUERY_PARAM': 'per_page',
 
+    # NO_COUNT_QUERY_PARAM: global setting for the query parameter that disables counts
+    # during pagination
+    # Can be overriden at the viewset level.
+    'NO_COUNT_QUERY_PARAM': 'exclude_count',
+
     # ADDITIONAL_PRIMARY_RESOURCE_PREFIX: String to prefix additional
     # instances of the primary resource when sideloading.
     'ADDITIONAL_PRIMARY_RESOURCE_PREFIX': '+',

--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -18,6 +18,7 @@ class DynamicPageNumberPagination(PageNumberPagination):
     Adds support for pagination metadata and overrides for
     pagination query parameters.
     """
+
     page_size_query_param = settings.PAGE_SIZE_QUERY_PARAM
     exclude_count_query_param = settings.EXCLUDE_COUNT_QUERY_PARAM
     page_query_param = settings.PAGE_QUERY_PARAM
@@ -26,8 +27,9 @@ class DynamicPageNumberPagination(PageNumberPagination):
     django_paginator_class = DynamicPaginator
 
     def get_page_metadata(self):
-        # returns page, per_page
-        # also returns total_results and total_pages, unless EXCLUDE_COUNT_QUERY_PARAM is set
+        # always returns page, per_page
+        # also returns total_results and total_pages
+        # (unless EXCLUDE_COUNT_QUERY_PARAM is set)
         meta = {
             'page': self.page.number,
             'per_page': self.get_page_size(self.request)
@@ -81,7 +83,9 @@ class DynamicPageNumberPagination(PageNumberPagination):
             return None
 
         self.request = request
-        paginator = self.django_paginator_class(queryset, page_size, exclude_count=self.exclude_count)
+        paginator = self.django_paginator_class(
+            queryset, page_size, exclude_count=self.exclude_count
+        )
         page_number = self.get_page_number(request, paginator)
 
         try:

--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -51,8 +51,8 @@ class DynamicPageNumberPagination(PageNumberPagination):
             result['results'] = data
             result['meta'] = meta
         else:
-            result = {}
-            if 'meta' in data:
+            result = data
+            if 'meta' in result:
                 result['meta'].update(meta)
             else:
                 result['meta'] = meta

--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -4,8 +4,12 @@ from collections import OrderedDict
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
+from rest_framework.exceptions import NotFound
 
+from django.utils.functional import cached_property
+from django.core.paginator import InvalidPage
 from dynamic_rest.conf import settings
+from dynamic_rest.paginator import DynamicPaginator
 
 
 class DynamicPageNumberPagination(PageNumberPagination):
@@ -15,32 +19,83 @@ class DynamicPageNumberPagination(PageNumberPagination):
     pagination query parameters.
     """
     page_size_query_param = settings.PAGE_SIZE_QUERY_PARAM
+    exclude_count_query_param = settings.EXCLUDE_COUNT_QUERY_PARAM
     page_query_param = settings.PAGE_QUERY_PARAM
     max_page_size = settings.MAX_PAGE_SIZE
     page_size = settings.PAGE_SIZE or api_settings.PAGE_SIZE
+    django_paginator_class = DynamicPaginator
 
     def get_page_metadata(self):
-        # returns total_results, total_pages, page, per_page
-        return {
-            'total_results': self.page.paginator.count,
-            'total_pages': self.page.paginator.num_pages,
+        # returns page, per_page
+        # also returns total_results and total_pages, unless EXCLUDE_COUNT_QUERY_PARAM is set
+        meta = {
             'page': self.page.number,
             'per_page': self.get_page_size(self.request)
         }
+        if not self.exclude_count:
+            meta['total_results'] = self.page.paginator.count
+            meta['total_pages'] = self.page.paginator.num_pages
+        else:
+            meta['more_pages'] = self.more_pages
+        return meta
 
     def get_paginated_response(self, data):
         meta = self.get_page_metadata()
+        result = None
         if isinstance(data, list):
-            data = OrderedDict([
-                ('count', self.page.paginator.count),
-                ('next', self.get_next_link()),
-                ('previous', self.get_previous_link()),
-                ('results', data),
-                ('meta', meta)
-            ])
+            result = OrderedDict()
+            if not self.exclude_count:
+                result['count'] = self.page.paginator.count
+                result['next'] = self.get_next_link()
+                result['previous'] = self.get_previous_link()
+            result['results'] = data
+            result['meta'] = meta
         else:
+            result = {}
             if 'meta' in data:
-                data['meta'].update(meta)
+                result['meta'].update(meta)
             else:
-                data['meta'] = meta
-        return Response(data)
+                result['meta'] = meta
+        return Response(result)
+
+    @cached_property
+    def exclude_count(self):
+        return self.request.query_params.get(self.EXCLUDE_COUNT_QUERY_PARAM)
+
+    def paginate_queryset(self, queryset, request, **other):
+        """
+        Paginate a queryset if required, either returning a
+        page object, or `None` if pagination is not configured for this view.
+        """
+        if 'exclude_count' in self.__dict__:
+            self.__dict__.pop('exclude_count')
+
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        self.request = request
+        paginator = self.django_paginator_class(queryset, page_size, exclude_count=self.exclude_count)
+        page_number = self.get_page_number(request, paginator)
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=str(exc)
+            )
+            raise NotFound(msg)
+
+        if paginator.num_pages > 1 and self.template is not None:
+            # The browsable API should display pagination controls.
+            self.display_page_controls = True
+
+        result = list(self.page)
+        if self.exclude_count:
+            if len(result) > page_size:
+                # if exclude_count is set, we fetch one extra item
+                result = result[:page_size]
+                self.more_pages = True
+            else:
+                self.more_pages = False
+        return result

--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -60,7 +60,7 @@ class DynamicPageNumberPagination(PageNumberPagination):
 
     @cached_property
     def exclude_count(self):
-        return self.request.query_params.get(self.EXCLUDE_COUNT_QUERY_PARAM)
+        return self.request.query_params.get(self.exclude_count_query_param)
 
     def paginate_queryset(self, queryset, request, **other):
         """

--- a/dynamic_rest/pagination.py
+++ b/dynamic_rest/pagination.py
@@ -62,6 +62,12 @@ class DynamicPageNumberPagination(PageNumberPagination):
     def exclude_count(self):
         return self.request.query_params.get(self.exclude_count_query_param)
 
+    def get_page_number(self, request, paginator):
+        page_number = request.query_params.get(self.page_query_param, 1)
+        if page_number in self.last_page_strings:
+            page_number = paginator.num_pages
+        return page_number
+
     def paginate_queryset(self, queryset, request, **other):
         """
         Paginate a queryset if required, either returning a

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -1,3 +1,6 @@
+# adapter from Django's django.core.paginator
+# adds support for the "exclude_count" parameter
+
 from math import ceil
 
 from django.utils.functional import cached_property
@@ -58,7 +61,7 @@ class DynamicPaginator(Paginator):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
         if self.exclude_count:
-            # fetch one extra item to determine if more pages are available
+            # always fetch one extra item to determine if more pages are available
             top = top + 1
         else:
             # skip validating against count

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -1,0 +1,94 @@
+from math import ceil
+
+from django.utils.functional import cached_property
+from django.core.paginator import Paginator
+
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    def _(x):
+        return x
+
+
+
+class InvalidPage(Exception):
+    pass
+
+
+class PageNotAnInteger(InvalidPage):
+    pass
+
+
+class EmptyPage(InvalidPage):
+    pass
+
+
+class DynamicPaginator(Paginator):
+
+    def __init__(self, object_list, per_page, orphans=0,
+                 allow_empty_first_page=True, exclude_count=False):
+        self.object_list = object_list
+        self._check_object_list_is_ordered()
+        self.per_page = int(per_page)
+        self.orphans = int(orphans)
+        self.allow_empty_first_page = allow_empty_first_page
+        self.exclude_count = exclude_count
+
+    def validate_number(self, number):
+        """Validate the given 1-based page number."""
+        try:
+            number = int(number)
+        except (TypeError, ValueError):
+            raise PageNotAnInteger(_('That page number is not an integer'))
+        if number < 1:
+            raise EmptyPage(_('That page number is less than 1'))
+        if self.exclude_count:
+            # skip validating against num_pages
+            return number
+        if number > self.num_pages:
+            if number == 1 and self.allow_empty_first_page:
+                pass
+            else:
+                raise EmptyPage(_('That page contains no results'))
+        return number
+
+    def page(self, number):
+        """Return a Page object for the given 1-based page number."""
+        number = self.validate_number(number)
+        bottom = (number - 1) * self.per_page
+        top = bottom + self.per_page
+        if self.exclude_count:
+            # fetch one extra item to determine if more pages are available
+            top = top + 1
+        else:
+            # skip validating against count
+            if top + self.orphans >= self.count:
+                top = self.count
+        return self._get_page(self.object_list[bottom:top], number, self)
+
+    @cached_property
+    def count(self):
+        """Return the total number of objects, across all pages."""
+        if self.exclude_count:
+            # always return 0, count should not be called
+            return 0
+
+        try:
+            return self.object_list.count()
+        except (AttributeError, TypeError):
+            # AttributeError if object_list has no count() method.
+            # TypeError if object_list.count() requires arguments
+            # (i.e. is of type list).
+            return len(self.object_list)
+
+    @cached_property
+    def num_pages(self):
+        """Return the total number of pages."""
+        if self.exclude_count:
+            # always return 1, count should not be called
+            return 1
+
+        if self.count == 0 and not self.allow_empty_first_page:
+            return 0
+        hits = max(1, self.count - self.orphans)
+        return int(ceil(hits / float(self.per_page)))

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -1,4 +1,4 @@
-# adapter from Django's django.core.paginator
+# adapted from Django's django.core.paginator (2.2 - 3.2+ compatible)
 # adds support for the "exclude_count" parameter
 
 from math import ceil

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -29,14 +29,9 @@ class EmptyPage(InvalidPage):
 
 class DynamicPaginator(Paginator):
 
-    def __init__(self, object_list, per_page, orphans=0,
-                 allow_empty_first_page=True, exclude_count=False):
-        self.object_list = object_list
-        self._check_object_list_is_ordered()
-        self.per_page = int(per_page)
-        self.orphans = int(orphans)
-        self.allow_empty_first_page = allow_empty_first_page
-        self.exclude_count = exclude_count
+    def __init__(self, *args, **kwargs):
+        self.exclude_count = kwargs.pop('exclude_count', False)
+        super().__init__(*args, **kwargs)
 
     def validate_number(self, number):
         """Validate the given 1-based page number."""
@@ -64,9 +59,9 @@ class DynamicPaginator(Paginator):
         if self.exclude_count:
             # always fetch one extra item
             # to determine if more pages are available
+            # and skip validation against count
             top = top + 1
         else:
-            # skip validating against count
             if top + self.orphans >= self.count:
                 top = self.count
         return self._get_page(self.object_list[bottom:top], number, self)

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -15,7 +15,6 @@ except ImportError:
         return x
 
 
-
 class InvalidPage(Exception):
     pass
 
@@ -63,7 +62,8 @@ class DynamicPaginator(Paginator):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
         if self.exclude_count:
-            # always fetch one extra item to determine if more pages are available
+            # always fetch one extra item
+            # to determine if more pages are available
             top = top + 1
         else:
             # skip validating against count

--- a/dynamic_rest/paginator.py
+++ b/dynamic_rest/paginator.py
@@ -3,8 +3,10 @@
 
 from math import ceil
 
+import inspect
 from django.utils.functional import cached_property
 from django.core.paginator import Paginator
+from django.utils.inspect import method_has_no_args
 
 try:
     from django.utils.translation import gettext_lazy as _
@@ -76,13 +78,10 @@ class DynamicPaginator(Paginator):
             # always return 0, count should not be called
             return 0
 
-        try:
-            return self.object_list.count()
-        except (AttributeError, TypeError):
-            # AttributeError if object_list has no count() method.
-            # TypeError if object_list.count() requires arguments
-            # (i.e. is of type list).
-            return len(self.object_list)
+        c = getattr(self.object_list, 'count', None)
+        if callable(c) and not inspect.isbuiltin(c) and method_has_no_args(c):
+            return c()
+        return len(self.object_list)
 
     @cached_property
     def num_pages(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest'
 DESCRIPTION = 'Dynamic API support to Django REST Framework.'
 URL = 'http://github.com/AltSchool/dynamic-rest'
-VERSION = '2.1.2'
+VERSION = '2.1.3'
 SCRIPTS = ['manage.py']
 
 setup(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1099,7 +1099,7 @@ class TestAlternateLocationsAPI(APITestCase):
         # sanity check: standard filter returns 1 result
         r = self.client.get('/alternate_locations/?filter{users.last_name}=1')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(r.data['locations']), 1)
+        self.assertEqual(len(r.data.get('locations', [])), 1, r.data)
         location = r.data['locations'][0]
         self.assertEqual(location['name'], '0')
 


### PR DESCRIPTION
...to support a faster page-number pagination over large datasets

- Like standard `PageNumberPagination`, except the results are never counted
- Uses the N+1 trick from `CursorPagination` to determine whether the dataset has more pages
- Can be enabled on any request via query parameter `exclude_count` (name can be configured)

TODO: 
- [x] ensure all current tests pass
- [x] add new test case with `exclude_count` enabled