### PR TITLE
fix: remove deprecated NullBooleanField

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -7,7 +7,7 @@ import six
 from functools import reduce
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, NullBooleanField
+from rest_framework.fields import BooleanField
 from rest_framework.filters import BaseFilterBackend, OrderingFilter
 
 from dynamic_rest.utils import is_truthy
@@ -148,7 +148,7 @@ def rewrite_filters(fs, serializer):
     out = {}
     for node in fs.values():
         filter_key, field = node.generate_query_key(serializer)
-        if isinstance(field, (BooleanField, NullBooleanField)):
+        if isinstance(field, BooleanField):
             node.value = is_truthy(node.value)
         out[filter_key] = node.value
 


### PR DESCRIPTION
`NullBooleanField` was used in `dynamic_rest/fields.py`, to `Convert filter values to booleans for boolean fields` - https://github.com/AltSchool/dynamic-rest/pull/124. It should not break anything else. `NullBooleanField` is deprecated on DRF 3.14 - https://github.com/encode/django-rest-framework/pull/8599/commits/d6b87b0b0ea847d00156936908124051908874d3. 

Related issue: https://github.com/AltSchool/dynamic-rest/issues/350