### PR TITLE
Django 4.2 support

### DIFF
--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -5,9 +5,14 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q, Prefetch, Manager
 import six
 from functools import reduce
+from rest_framework import __version__ as drf_version
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, NullBooleanField
+try:
+    from rest_framework.fields import BooleanField, NullBooleanField
+except ImportError:
+    # DRF >= 3.14.0
+    from rest_framework.fields import BooleanField
 from rest_framework.filters import BaseFilterBackend, OrderingFilter
 
 from dynamic_rest.utils import is_truthy
@@ -25,6 +30,13 @@ from dynamic_rest.prefetch import FastQuery, FastPrefetch
 from dynamic_rest.related import RelatedObject
 
 patch_prefetch_one_level()
+
+DRF_VERSION = drf_version.split('.')
+if int(DRF_VERSION[0]) >= 3 and int(DRF_VERSION[1]) >= 14:
+    # NullBooleanField deprecated in DRF >= 3.14
+    DRF_BOOLEAN_FIELD = BooleanField
+else:
+    DRF_BOOLEAN_FIELD = (BooleanField, NullBooleanField)
 
 
 def OR(a, b):
@@ -148,7 +160,7 @@ def rewrite_filters(fs, serializer):
     out = {}
     for node in fs.values():
         filter_key, field = node.generate_query_key(serializer)
-        if isinstance(field, (BooleanField, NullBooleanField)):
+        if isinstance(field, DRF_BOOLEAN_FIELD):
             node.value = is_truthy(node.value)
         out[filter_key] = node.value
 

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
-Django>=2.2,<4.2
+Django>=2.2,<4.3
 djangorestframework>=3.11.2,<3.15
 inflection>=0.4.0
 requests

--- a/requirements.benchmark.txt
+++ b/requirements.benchmark.txt
@@ -1,6 +1,6 @@
 dj-database-url==0.3.0
 django-debug-toolbar==1.7
-Django>=2.2,<4.2
+Django>=2.2,<4.3
 djangorestframework>=3.11.2,<3.15
 djay>=0.0.9
 flake8>=3.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ addopts=--tb=short
 [tox]
 envlist =
        py310-lint,
-       {py37,py38,py39,py310}-django{22,31,32,40,41}-drf{311,312,313,314},
+       {py37,py38,py39,py310}-django{22,31,32,40,41,42}-drf{311,312,313,314},
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
@@ -16,6 +16,7 @@ deps =
         django32: Django>=3.2,<3.3
         django40: Django>=4.0,<4.1
         django41: Django>=4.1,<4.2
+        django42: Django>=4.2,<4.3
         drf311: djangorestframework>=3.11.2,<3.12
         drf312: djangorestframework>=3.12,<3.13
         drf313: djangorestframework>=3.13,<3.14
@@ -29,6 +30,6 @@ deps = -rrequirements.txt
 [testenv:py310-drf314-benchmarks]
 commands = ./runtests.py --benchmarks
 deps =
-        Django==4.1.1
+        Django==4.2.1
         djangorestframework==3.14
         -rrequirements.benchmark.txt


### PR DESCRIPTION
- Django 4.2
- NullBooleanField deprecated in [DRF 3.14.0](https://github.com/encode/django-rest-framework/pull/8599)