### PR TITLE
Drop "six" package

### DIFF
--- a/dynamic_rest/datastructures.py
+++ b/dynamic_rest/datastructures.py
@@ -1,5 +1,4 @@
 """This module contains custom data-structures."""
-import six
 
 
 class TreeMap(dict):
@@ -15,7 +14,7 @@ class TreeMap(dict):
             A list of lists of paths.
         """
         paths = []
-        for key, child in six.iteritems(self):
+        for key, child in self.items():
             if isinstance(child, TreeMap) and child:
                 # current child is an intermediate node
                 for path in child.get_paths():

--- a/dynamic_rest/fields/fields.py
+++ b/dynamic_rest/fields/fields.py
@@ -3,7 +3,6 @@
 import importlib
 import pickle
 
-import six
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.functional import cached_property
 from rest_framework import fields
@@ -245,7 +244,7 @@ class DynamicRelationField(WithRelationalFieldMixin, DynamicField):
     def get_serializer(self, *args, **kwargs):
         """Get an instance of the child serializer."""
         init_args = {
-            k: v for k, v in six.iteritems(self.kwargs)
+            k: v for k, v in self.kwargs.items()
             if k in self.SERIALIZER_KWARGS
         }
 
@@ -353,7 +352,7 @@ class DynamicRelationField(WithRelationalFieldMixin, DynamicField):
         Resolves string imports.
         """
         serializer_class = self._serializer_class
-        if not isinstance(serializer_class, six.string_types):
+        if not isinstance(serializer_class, str):
             return serializer_class
 
         parts = serializer_class.split('.')

--- a/dynamic_rest/filters.py
+++ b/dynamic_rest/filters.py
@@ -3,7 +3,6 @@
 from django.core.exceptions import ValidationError as InternalValidationError
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q, Prefetch, Manager
-import six
 from functools import reduce
 from rest_framework import __version__ as drf_version
 from rest_framework import serializers
@@ -53,7 +52,7 @@ def has_joins(queryset):
     If this is the case, it is possible for the queryset
     to return duplicate results.
     """
-    for join in six.itervalues(queryset.query.alias_map):
+    for join in queryset.query.alias_map.values():
         if join.join_type:
             return True
     return False
@@ -277,7 +276,7 @@ class DynamicFilterBackend(BaseFilterBackend):
         if getattr(self, 'view', None):
             out['_complex'] = self.view.get_request_feature(self.view.FILTER, raw=True)
 
-        for spec, value in six.iteritems(filters_map):
+        for spec, value in filters_map.items():
 
             # Inclusion or exclusion?
             if spec[0] == '-':
@@ -309,7 +308,7 @@ class DynamicFilterBackend(BaseFilterBackend):
                 pass
             elif operator in self.VALID_FILTER_OPERATORS:
                 value = value[0]
-                if operator == 'isnull' and isinstance(value, six.string_types):
+                if operator == 'isnull' and isinstance(value, str):
                     value = is_truthy(value)
                 elif operator == 'eq':
                     operator = None
@@ -360,7 +359,7 @@ class DynamicFilterBackend(BaseFilterBackend):
                 q &= Q(**includes)
             if excludes:
                 excludes = rewrite_filters(excludes, serializer)
-                for k, v in six.iteritems(excludes):
+                for k, v in excludes.items():
                     q &= ~Q(**{k: v})
             return q
         else:
@@ -391,8 +390,8 @@ class DynamicFilterBackend(BaseFilterBackend):
     def _build_implicit_prefetches(self, model, prefetches, requirements):
         """Build a prefetch dictionary based on internal requirements."""
 
-        for source, remainder in six.iteritems(requirements):
-            if not remainder or isinstance(remainder, six.string_types):
+        for source, remainder in requirements.items():
+            if not remainder or isinstance(remainder, str):
                 # no further requirements to prefetch
                 continue
 
@@ -429,7 +428,7 @@ class DynamicFilterBackend(BaseFilterBackend):
     ):
         """Build a prefetch dictionary based on request requirements."""
 
-        for name, field in six.iteritems(fields):
+        for name, field in fields.items():
             original_field = field
             if isinstance(field, DynamicRelationField):
                 field = field.serializer
@@ -480,7 +479,7 @@ class DynamicFilterBackend(BaseFilterBackend):
 
     def _get_implicit_requirements(self, fields, requirements):
         """Extract internal prefetch requirements from serializer fields."""
-        for name, field in six.iteritems(fields):
+        for name, field in fields.items():
             source = field.source
             # Requires may be manually set on the field -- if not,
             # assume the field requires only its source.

--- a/dynamic_rest/links.py
+++ b/dynamic_rest/links.py
@@ -1,5 +1,4 @@
 """This module contains utilities to support API links."""
-import six
 from dynamic_rest.conf import settings
 from dynamic_rest.routers import DynamicRouter
 
@@ -20,7 +19,7 @@ def merge_link_object(serializer, data, instance):
         return data
 
     link_fields = serializer.get_link_fields()
-    for name, field in six.iteritems(link_fields):
+    for name, field in link_fields.items():
         # For included fields, omit link if there's no data.
         if name in data and not data[name]:
             continue

--- a/dynamic_rest/processors.py
+++ b/dynamic_rest/processors.py
@@ -1,7 +1,6 @@
 """This module contains response processors."""
 from collections import defaultdict
 
-import six
 from rest_framework.serializers import ListSerializer
 from rest_framework.utils.serializer_helpers import ReturnDict
 
@@ -96,7 +95,7 @@ class SideloadingProcessor(object):
             returned = isinstance(obj, ReturnDict)
             if dynamic or returned:
                 # recursively check all fields
-                for key, o in six.iteritems(obj):
+                for key, o in obj.items():
                     if isinstance(o, list) or isinstance(o, dict):
                         # lists or dicts indicate a relation
                         self.process(

--- a/dynamic_rest/routers.py
+++ b/dynamic_rest/routers.py
@@ -8,8 +8,6 @@ try:
 except ImportError:
     from django.core.urlresolvers import get_script_prefix
 
-import six
-
 import rest_framework
 from rest_framework import views
 from rest_framework.response import Response
@@ -60,12 +58,12 @@ def get_directory(request):
     # structure, for now it is capped at a single level
     # for UX reasons
     for group_name, endpoints in sorted(
-        six.iteritems(directory),
+        directory.items(),
         key=sort_key
     ):
         endpoints_list = []
         for endpoint_name, endpoint in sorted(
-            six.iteritems(endpoints),
+            endpoints.items(),
             key=sort_key
         ):
             if endpoint_name[:1] == '_':
@@ -331,7 +329,7 @@ class DynamicRouter(DefaultRouter):
             return routes
 
         serializer = viewset.serializer_class()
-        fields = getattr(serializer, 'get_link_fields', lambda: [])()
+        fields = getattr(serializer, 'get_link_fields', lambda: {})()
 
         route_name = '{basename}-{methodnamehyphen}'
         if drf_version >= (3, 8, 0):
@@ -339,7 +337,7 @@ class DynamicRouter(DefaultRouter):
         else:
             route_compat_kwargs = {}
 
-        for field_name, field in six.iteritems(fields):
+        for field_name, field in fields.items():
             methodname = 'list_related'
             url = (
                 r'^{prefix}/{lookup}/(?P<field_name>%s)'

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -5,7 +5,6 @@ import os
 
 import inflection
 from django.db import models
-import six
 from django.utils.functional import cached_property
 from rest_framework import __version__ as drf_version
 from rest_framework import exceptions, fields, serializers
@@ -236,7 +235,7 @@ class WithDynamicSerializerMixin(
             # passes null as a value, remove the field from the data
             # this addresses the frontends that send
             # undefined resource fields as null on POST/PUT
-            for field_name, field in six.iteritems(self.get_all_fields()):
+            for field_name, field in self.get_all_fields().items():
                 if (
                     field.allow_null is False and
                     field.required is False and
@@ -304,7 +303,7 @@ class WithDynamicSerializerMixin(
             # First exclude all, then add back in explicitly included fields.
             include_fields = set(
                 list(include_fields) + [
-                    field for field, val in six.iteritems(self.request_fields)
+                    field for field, val in self.request_fields.items()
                     if val or val == {}
                 ]
             )
@@ -393,11 +392,11 @@ class WithDynamicSerializerMixin(
                 FIELDS_CACHE[self.__class__] = all_fields
         else:
             all_fields = copy.copy(FIELDS_CACHE[self.__class__])
-            for k, field in six.iteritems(all_fields):
+            for k, field in all_fields.items():
                 if hasattr(field, 'reset'):
                     field.reset()
 
-        for k, field in six.iteritems(all_fields):
+        for k, field in all_fields.items():
             field.field_name = k
             field.parent = self
 
@@ -411,7 +410,7 @@ class WithDynamicSerializerMixin(
             meta_attr = '%s_fields' % attr
         meta_list = set(getattr(self.Meta, meta_attr, []))
         return {
-            name for name, field in six.iteritems(fields)
+            name for name, field in fields.items()
             if getattr(field, attr, None) is True or name in
             meta_list
         }
@@ -460,7 +459,7 @@ class WithDynamicSerializerMixin(
 
         # apply request overrides
         if request_fields:
-            for name, include in six.iteritems(request_fields):
+            for name, include in request_fields.items():
                 if name not in serializer_fields:
                     raise exceptions.ParseError(
                         '"%s" is not a valid field name for "%s".' %
@@ -520,7 +519,7 @@ class WithDynamicSerializerMixin(
         else:
             all_fields = self.get_all_fields()
             return {
-                name: field for name, field in six.iteritems(all_fields)
+                name: field for name, field in all_fields.items()
                 if isinstance(field, DynamicRelationField) and
                 getattr(field, 'link', True) and
                 not (

--- a/dynamic_rest/utils.py
+++ b/dynamic_rest/utils.py
@@ -4,8 +4,6 @@ from django.utils.module_loading import import_string
 
 from hashids import Hashids
 
-from six import string_types
-
 from dynamic_rest.conf import settings
 
 
@@ -17,7 +15,7 @@ FALSEY_STRINGS = (
 
 
 def is_truthy(x):
-    if isinstance(x, string_types):
+    if isinstance(x, str):
         return x.lower() not in FALSEY_STRINGS
     return bool(x)
 

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -1,7 +1,6 @@
 """This module contains custom viewset classes."""
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import QueryDict
-import six
 import json
 from django.db import transaction, IntegrityError
 from rest_framework import exceptions, status, viewsets
@@ -34,7 +33,7 @@ class QueryParams(QueryDict):
         else:
             assert isinstance(
                 query_params,
-                (six.string_types, six.binary_type)
+                (str, bytes)
             )
             query_string = query_params
         kwargs['mutable'] = True
@@ -461,7 +460,7 @@ class DynamicModelViewSet(WithDynamicViewSetMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer()
         fields = serializer.get_all_fields()
         validated = {}
-        for name, value in six.iteritems(data):
+        for name, value in data.items():
             field = fields.get(name, None)
             if field is None:
                 raise ValidationError(
@@ -495,7 +494,7 @@ class DynamicModelViewSet(WithDynamicViewSetMixin, viewsets.ModelViewSet):
         try:
             with transaction.atomic():
                 for record in queryset:
-                    for k, v in six.iteritems(data):
+                    for k, v in data.items():
                         setattr(record, k, v)
                     record.save()
                     updated += 1

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -3,4 +3,3 @@ djangorestframework>=3.13,<3.16
 inflection>=0.4.0
 requests
 hashids>=1.3.1
-six>=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pytest-cov==3.0.0
 pytest-django==4.5.2
 pytest-sugar==0.9.5
 pytest>=7.0.0
-six==1.16.0
 Sphinx==1.7.5
 tox-pyenv==1.1.0
 tox==3.25.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,6 @@ import json
 import django
 from django.db import connection
 from django.test import override_settings
-import six
 from rest_framework.test import APITestCase
 from urllib.parse import quote
 
@@ -12,7 +11,7 @@ from tests.models import Cat, Group, Location, Permission, Profile, User
 from tests.serializers import NestedEphemeralSerializer, PermissionSerializer
 from tests.setup import create_fixture
 
-UNICODE_STRING = six.unichr(9629)  # unicode heart
+UNICODE_STRING = chr(9629)  # unicode heart
 # UNICODE_URL_STRING = urllib.quote(UNICODE_STRING.encode('utf-8'))
 UNICODE_URL_STRING = '%E2%96%9D'
 
@@ -353,7 +352,7 @@ class TestUsersAPI(APITestCase):
             json.loads(response.content.decode('utf-8')))
         with self.assertNumQueries(1):
             response = self.client.get(
-                six.u('/users/?filter{name}[]=%s') % UNICODE_STRING
+                str('/users/?filter{name}[]=%s') % UNICODE_STRING
             )
         self.assertEqual(200, response.status_code)
         self.assertEqual(
@@ -380,7 +379,7 @@ class TestUsersAPI(APITestCase):
         )
         with self.assertNumQueries(1):
             response = self.client.get(
-                six.u('/users/?filter{name}[]=%s') % UNICODE_STRING
+                str('/users/?filter{name}[]=%s') % UNICODE_STRING
             )
         self.assertEqual(200, response.status_code)
         self.assertEqual(

--- a/tests/test_prefetch2.py
+++ b/tests/test_prefetch2.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.test import APITestCase
 
 from dynamic_rest.prefetch import FastPrefetch, FastQuery
@@ -135,7 +133,7 @@ class TestFastQuery(APITestCase):
         self.assertTrue(
             all(['user_set' in obj for obj in result])
         )
-        location = six.next((
+        location = next((
             o for o in result if o['user_set'] and len(o['user_set']) > 1
         ))
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,7 +3,6 @@ from mock import patch
 from collections import OrderedDict
 
 from django.test import TestCase, override_settings
-import six
 
 from dynamic_rest.fields import DynamicRelationField
 from dynamic_rest.processors import register_post_processor
@@ -414,17 +413,17 @@ class TestDynamicSerializer(TestCase):
 
     def test_get_all_fields(self):
         s = GroupSerializer()
-        all_keys1 = six.iterkeys(s.get_all_fields())
+        all_keys1 = s.get_all_fields().keys()
         f2 = s.fields
-        all_keys2 = six.iterkeys(s.get_all_fields())
+        all_keys2 = s.get_all_fields().keys()
         expected = ['id', 'name']
-        self.assertEqual(list(six.iterkeys(f2)), expected)
+        self.assertEqual(list(f2.keys()), expected)
         self.assertEqual(list(all_keys1), list(all_keys2))
 
     def test_get_fields_with_only_fields(self):
         expected = ['id', 'last_name']
         serializer = UserSerializer(only_fields=expected)
-        self.assertEqual(list(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(list(serializer.fields.keys()), expected)
 
     def test_get_fields_with_only_fields_and_request_fields(self):
         expected = ['id', 'permissions']
@@ -434,7 +433,7 @@ class TestDynamicSerializer(TestCase):
                 'permissions': {}
             }
         )
-        self.assertEqual(list(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(list(serializer.fields.keys()), expected)
         self.assertEqual(serializer.request_fields['permissions'], {})
 
     def test_get_fields_with_only_fields_and_include_fields(self):
@@ -443,37 +442,37 @@ class TestDynamicSerializer(TestCase):
             only_fields=expected,
             include_fields=['permissions']
         )
-        self.assertEqual(list(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(list(serializer.fields.keys()), expected)
 
     def test_get_fields_with_include_all(self):
-        expected = six.iterkeys(UserSerializer().get_all_fields())
+        expected = UserSerializer().get_all_fields().keys()
         serializer = UserSerializer(
             include_fields='*'
         )
-        self.assertEqual(list(six.iterkeys(serializer.fields)), list(expected))
+        self.assertEqual(list(serializer.fields.keys()), list(expected))
 
     def test_get_fields_with_include_all_and_exclude(self):
-        expected = six.iterkeys(UserSerializer().get_all_fields())
+        expected = UserSerializer().get_all_fields().keys()
         serializer = UserSerializer(
             include_fields='*',
             exclude_fields=['id']
         )
-        self.assertEqual(list(six.iterkeys(serializer.fields)), list(expected))
+        self.assertEqual(list(serializer.fields.keys()), list(expected))
 
     def test_get_fields_with_include_fields(self):
         include = ['permissions']
         expected = set(
-            six.iterkeys(UserSerializer().get_fields())
+            UserSerializer().get_fields().keys()
         ) | set(include)
         serializer = UserSerializer(
             include_fields=include
         )
-        self.assertEqual(set(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(set(serializer.fields.keys()), expected)
 
     def test_get_fields_with_include_fields_and_request_fields(self):
         include = ['permissions']
         expected = set(
-            six.iterkeys(UserSerializer().get_fields())
+            UserSerializer().get_fields().keys()
         ) | set(include)
         serializer = UserSerializer(
             include_fields=include,
@@ -481,18 +480,18 @@ class TestDynamicSerializer(TestCase):
                 'permissions': {}
             }
         )
-        self.assertEqual(set(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(set(serializer.fields.keys()), expected)
         self.assertEqual(serializer.request_fields['permissions'], {})
 
     def test_get_fields_with_exclude_fields(self):
         exclude = ['id']
         expected = set(
-            six.iterkeys(UserSerializer().get_fields())
+            UserSerializer().get_fields().keys()
         ) - set(exclude)
         serializer = UserSerializer(
             exclude_fields=exclude,
         )
-        self.assertEqual(set(six.iterkeys(serializer.fields)), expected)
+        self.assertEqual(set(serializer.fields.keys()), expected)
 
     def test_serializer_propagation_consistency(self):
         s = CatSerializer(


### PR DESCRIPTION
Since dynamic-rest is using modern Py3 interpreters - we can now remove "six" package from lib and replace it with Py3 methods

plus: fixed some potent bug in file dynamic_rest/routers.py line 332
fields = getattr(serializer, 'get_link_fields', lambda: [])() to
fields = getattr(serializer, 'get_link_fields', lambda: {})()
because further line 340 use "fields" as dict